### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/syncloud/platform.png?label=ready&title=Ready)](https://waffle.io/syncloud/platform)
 [![Build Status](https://travis-ci.org/syncloud/platform.svg?branch=master)](https://travis-ci.org/syncloud/platform)
 # platform


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/syncloud/platform

This was requested by a real person (user cyberb) on waffle.io, we're not trying to spam you.