### PR TITLE
Add note from wiki about upgrade order

### DIFF
--- a/www/src/views/Updates.vue
+++ b/www/src/views/Updates.vue
@@ -15,6 +15,9 @@
               </button>
             </div>
             <div class="setline">
+              <span class="span">Note: upgrade System first if available before upgrading Installer.</span>
+            </div>
+            <div class="setline">
               <span class="span">System: </span>
               <span id="txt_platform_version" style="padding-right: 10px">{{ platformVersion }}</span>
               <button


### PR DESCRIPTION
If this wiki recommendation is still up to date, it might be better to directly specify it here.

I always go to the wiki to check because I never remember what is the good order...