### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/backend/access/port_probe_test.go
+++ b/backend/access/port_probe_test.go
@@ -3,11 +3,12 @@ package access
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/syncloud/platform/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/syncloud/platform/log"
 )
 
 type UserConfigStub struct {
@@ -36,7 +37,7 @@ func (c *ClientStub) Post(_, _ string, _ interface{}) (*http.Response, error) {
 		return nil, fmt.Errorf("error code: %v", c.status)
 	}
 
-	r := ioutil.NopCloser(bytes.NewReader([]byte(c.response)))
+	r := io.NopCloser(bytes.NewReader([]byte(c.response)))
 	return &http.Response{
 		StatusCode: c.status,
 		Body:       r,

--- a/backend/auth/ldap.go
+++ b/backend/auth/ldap.go
@@ -5,13 +5,13 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
-	"github.com/syncloud/platform/cli"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/syncloud/platform/cli"
 )
 
 const ldapUserConfDir = "slapd.d"
@@ -105,12 +105,12 @@ func (s *Service) Reset(name string, user string, password string, email string)
 
 	passwordHash := makeSecret(password)
 
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return err
 	}
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
-	file, err := ioutil.ReadFile(path.Join(s.configDir, "ldap", "init.ldif"))
+	file, err := os.ReadFile(path.Join(s.configDir, "ldap", "init.ldif"))
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (s *Service) Reset(name string, user string, password string, email string)
 	ldif = strings.ReplaceAll(ldif, "${user}", user)
 	ldif = strings.ReplaceAll(ldif, "${email}", email)
 	ldif = strings.ReplaceAll(ldif, "${password}", passwordHash)
-	err = ioutil.WriteFile(tmpFile.Name(), []byte(ldif), 644)
+	err = os.WriteFile(tmpFile.Name(), []byte(ldif), 644)
 	if err != nil {
 		return err
 	}

--- a/backend/auth/ldap_test.go
+++ b/backend/auth/ldap_test.go
@@ -2,12 +2,12 @@ package auth
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToLdapDc(t *testing.T) {
@@ -50,7 +50,7 @@ func TestMakeSecret(t *testing.T) {
 
 func TestInit(t *testing.T) {
 	executor := &ExecutorStub{}
-	ldap := New(&SnapServiceStub{}, createTempDir(), createTempDir(), createTempDir(), executor, &PasswordChangerStub{})
+	ldap := New(&SnapServiceStub{}, t.TempDir(), t.TempDir(), t.TempDir(), executor, &PasswordChangerStub{})
 	err := ldap.Init()
 	assert.Nil(t, err)
 	assert.Len(t, executor.executions, 1)
@@ -59,14 +59,14 @@ func TestInit(t *testing.T) {
 
 func TestReset(t *testing.T) {
 	executor := &ExecutorStub{}
-	configDir := createTempDir()
+	configDir := t.TempDir()
 	err := os.MkdirAll(path.Join(configDir, "ldap"), os.ModePerm)
 	assert.Nil(t, err)
 	err = os.WriteFile(path.Join(configDir, "ldap", "init.ldif"), []byte("template"), 0644)
 	assert.Nil(t, err)
 
 	passwordChanger := &PasswordChangerStub{}
-	ldap := New(&SnapServiceStub{}, createTempDir(), createTempDir(), configDir, executor, passwordChanger)
+	ldap := New(&SnapServiceStub{}, t.TempDir(), t.TempDir(), configDir, executor, passwordChanger)
 	err = ldap.Reset("name", "user", "password", "email")
 	assert.Nil(t, err)
 	assert.Len(t, executor.executions, 2)
@@ -74,12 +74,4 @@ func TestReset(t *testing.T) {
 	assert.Contains(t, executor.executions[1], "ldapadd.sh")
 	assert.True(t, passwordChanger.changed)
 
-}
-
-func createTempDir() string {
-	dir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		panic(err)
-	}
-	return dir
 }

--- a/backend/backup/backup.go
+++ b/backend/backup/backup.go
@@ -2,17 +2,17 @@ package backup
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
 	cp "github.com/otiai10/copy"
 	df "github.com/ricochet2200/go-disk-usage/du"
 	"github.com/syncloud/platform/cli"
 	"github.com/syncloud/platform/du"
 	"github.com/syncloud/platform/snap/model"
 	"go.uber.org/zap"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"regexp"
-	"time"
 )
 
 type SnapService interface {
@@ -66,7 +66,7 @@ func (b *Backup) Init() {
 }
 
 func (b *Backup) List() ([]File, error) {
-	files, err := ioutil.ReadDir(b.backupDir)
+	files, err := os.ReadDir(b.backupDir)
 	if err != nil {
 		b.logger.Error("Cannot get list of files in ", zap.String("backupDir", b.backupDir), zap.Error(err))
 		return nil, err

--- a/backend/cert/fake.go
+++ b/backend/cert/fake.go
@@ -8,11 +8,12 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"math/big"
+	"os"
+	"time"
+
 	"github.com/syncloud/platform/date"
 	"go.uber.org/zap"
-	"io/ioutil"
-	"math/big"
-	"time"
 )
 
 const (
@@ -92,12 +93,12 @@ func (c *Fake) Generate() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(c.systemConfig.SslCaKeyFile(), caPrivateKeyPem.Bytes(), 0644)
+	err = os.WriteFile(c.systemConfig.SslCaKeyFile(), caPrivateKeyPem.Bytes(), 0644)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(c.systemConfig.SslCaCertificateFile(), caPem.Bytes(), 0644)
+	err = os.WriteFile(c.systemConfig.SslCaCertificateFile(), caPem.Bytes(), 0644)
 	if err != nil {
 		return err
 	}
@@ -143,12 +144,12 @@ func (c *Fake) Generate() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(c.systemConfig.SslKeyFile(), privateKeyPem.Bytes(), 0644)
+	err = os.WriteFile(c.systemConfig.SslKeyFile(), privateKeyPem.Bytes(), 0644)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(c.systemConfig.SslCertificateFile(), certificatePem.Bytes(), 0644)
+	err = os.WriteFile(c.systemConfig.SslCertificateFile(), certificatePem.Bytes(), 0644)
 	if err != nil {
 		return err
 	}

--- a/backend/cert/generator.go
+++ b/backend/cert/generator.go
@@ -4,10 +4,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/syncloud/platform/date"
 	"go.uber.org/zap"
-	"io/ioutil"
-	"time"
 )
 
 const (
@@ -108,7 +109,7 @@ func (g *CertificateGenerator) generateFake() (bool, error) {
 
 func (g *CertificateGenerator) ReadCertificateInfo() *Info {
 
-	certBytes, err := ioutil.ReadFile(g.systemConfig.SslCertificateFile())
+	certBytes, err := os.ReadFile(g.systemConfig.SslCertificateFile())
 	if err != nil {
 		g.logger.Info(fmt.Sprintf("unable to read certificate file: %s", err.Error()))
 		return &Info{}

--- a/backend/cert/generator_test.go
+++ b/backend/cert/generator_test.go
@@ -2,12 +2,12 @@ package cert
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/syncloud/platform/log"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/syncloud/platform/log"
 )
 
 type GeneratorUserConfigStub struct {
@@ -225,19 +225,19 @@ func generateCertificate(now time.Time, duration time.Duration, real bool) *os.F
 		subjectOrganization = "Real"
 	}
 
-	certFile, err := ioutil.TempFile("", "")
+	certFile, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}
-	keyFile, err := ioutil.TempFile("", "")
+	keyFile, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}
-	caCertFile, err := ioutil.TempFile("", "")
+	caCertFile, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}
-	caKeyFile, err := ioutil.TempFile("", "")
+	caKeyFile, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}

--- a/backend/config/system_config_test.go
+++ b/backend/config/system_config_test.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSystemConfigInterpolation(t *testing.T) {
@@ -16,7 +16,7 @@ app_dir: test
 config_dir: %(app_dir)s/dir
 `
 
-	err := ioutil.WriteFile(configFile.Name(), []byte(content), 0644)
+	err := os.WriteFile(configFile.Name(), []byte(content), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/backend/config/user_config_test.go
+++ b/backend/config/user_config_test.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRedirectDomain(t *testing.T) {
@@ -70,7 +70,7 @@ func TestDeviceDomain_Custom(t *testing.T) {
 }
 
 func tempFile() *os.File {
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -95,7 +95,7 @@ user_email = user@example.com
 user_update_token = token2
 `
 
-	err := ioutil.WriteFile(oldConfigFile.Name(), []byte(content), 0644)
+	err := os.WriteFile(oldConfigFile.Name(), []byte(content), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/backend/ioc/ioc_test.go
+++ b/backend/ioc/ioc_test.go
@@ -1,18 +1,18 @@
 package ioc
 
 import (
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIoC(t *testing.T) {
-	configDb, err := ioutil.TempFile("", "")
+	configDb, err := os.CreateTemp("", "")
 	_ = os.Remove(configDb.Name())
 	assert.Nil(t, err)
-	systemConfig, err := ioutil.TempFile("", "")
+	systemConfig, err := os.CreateTemp("", "")
 	assert.Nil(t, err)
 	content := `
 [platform]
@@ -20,18 +20,13 @@ app_dir: test
 data_dir: test
 config_dir: test
 `
-	err = ioutil.WriteFile(systemConfig.Name(), []byte(content), 0644)
+	err = os.WriteFile(systemConfig.Name(), []byte(content), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	backupDir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
-	defer os.Remove(backupDir)
-
-	varDir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
-	defer os.Remove(varDir)
+	backupDir := t.TempDir()
+	varDir := t.TempDir()
 
 	Init(configDb.Name(), systemConfig.Name(), backupDir, varDir)
 }

--- a/backend/network/iface.go
+++ b/backend/network/iface.go
@@ -1,7 +1,7 @@
 package network
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 )
@@ -58,7 +58,7 @@ func (i *Interface) PublicIPv4() (*string, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	ipBytes, err := ioutil.ReadAll(resp.Body)
+	ipBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/nginx/service.go
+++ b/backend/nginx/service.go
@@ -1,7 +1,7 @@
 package nginx
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 )
@@ -40,7 +40,7 @@ func (n *Nginx) ReloadPublic() error {
 func (n *Nginx) InitConfig() error {
 	domain := n.userConfig.GetDeviceDomain()
 	configDir := n.systemConfig.ConfigDir()
-	templateFile, err := ioutil.ReadFile(path.Join(configDir, "nginx", "public.conf"))
+	templateFile, err := os.ReadFile(path.Join(configDir, "nginx", "public.conf"))
 	if err != nil {
 		return err
 	}
@@ -48,6 +48,6 @@ func (n *Nginx) InitConfig() error {
 	template = strings.ReplaceAll(template, "{{ domain }}", strings.ReplaceAll(domain, ".", "\\."))
 	nginxConfigDir := n.systemConfig.DataDir()
 	nginxConfigFile := path.Join(nginxConfigDir, "nginx.conf")
-	err = ioutil.WriteFile(nginxConfigFile, []byte(template), 0644)
+	err = os.WriteFile(nginxConfigFile, []byte(template), 0644)
 	return err
 }

--- a/backend/nginx/service_test.go
+++ b/backend/nginx/service_test.go
@@ -1,11 +1,11 @@
 package nginx
 
 import (
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type SystemdMock struct {
@@ -38,20 +38,18 @@ func (u *UserConfigMock) GetDeviceDomain() string {
 
 func TestSubstitution(t *testing.T) {
 
-	outputDir, err := ioutil.TempDir("", "")
-	defer func() { _ = os.Remove(outputDir) }()
+	outputDir := t.TempDir()
 
 	configDir := path.Join("..", "..", "config")
 	systemd := &SystemdMock{}
 	systemConfig := &SystemConfigMock{configDir: configDir, dataDir: outputDir}
 	userConfig := &UserConfigMock{"example.com"}
 	nginx := New(systemd, systemConfig, userConfig)
-	assert.Nil(t, err)
-	err = nginx.InitConfig()
+	err := nginx.InitConfig()
 	assert.Nil(t, err)
 	resultFile := path.Join(outputDir, "nginx.conf")
 
-	contents, err := ioutil.ReadFile(resultFile)
+	contents, err := os.ReadFile(resultFile)
 	assert.Nil(t, err)
 
 	assert.Contains(t, string(contents), "server_name example\\.com;")

--- a/backend/redirect/redirect_test.go
+++ b/backend/redirect/redirect_test.go
@@ -2,14 +2,14 @@ package redirect
 
 import (
 	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/syncloud/platform/identification"
 	"github.com/syncloud/platform/log"
-	"io/ioutil"
-	"net/http"
-
-	"net"
-	"testing"
 )
 
 type UserConfigStub struct {
@@ -63,7 +63,7 @@ func (c *ClientStub) Get(_ string) (*http.Response, error) {
 
 func (c *ClientStub) Post(_, _ string, body interface{}) (*http.Response, error) {
 	c.request = string(body.([]byte))
-	r := ioutil.NopCloser(bytes.NewReader([]byte(`
+	r := io.NopCloser(bytes.NewReader([]byte(`
 {
 	"success": true,
 	"data": ""

--- a/backend/snap/server.go
+++ b/backend/snap/server.go
@@ -3,12 +3,12 @@ package snap
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/syncloud/platform/snap/model"
-	"go.uber.org/zap"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
+
+	"github.com/syncloud/platform/snap/model"
+	"go.uber.org/zap"
 )
 
 const (
@@ -130,7 +130,7 @@ func (s *Server) request(url string) ([]byte, error) {
 		s.logger.Error("status", zap.Error(err))
 		return nil, fmt.Errorf("unable to get apps list, status code: %d", resp.StatusCode)
 	}
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		s.logger.Error("cannot read output", zap.Error(err))
 		return nil, err

--- a/backend/snap/server_test.go
+++ b/backend/snap/server_test.go
@@ -3,11 +3,12 @@ package snap
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/syncloud/platform/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/syncloud/platform/log"
 )
 
 type ClientStub struct {
@@ -19,7 +20,7 @@ func (c *ClientStub) Get(_ string) (resp *http.Response, err error) {
 	if c.error {
 		return nil, fmt.Errorf("error")
 	}
-	r := ioutil.NopCloser(bytes.NewReader([]byte(c.json)))
+	r := io.NopCloser(bytes.NewReader([]byte(c.json)))
 	return &http.Response{
 		StatusCode: 200,
 		Body:       r,
@@ -48,7 +49,7 @@ func (h HttpClientStub) Get(_ string) (*http.Response, error) {
 		return nil, fmt.Errorf("error code: %v", h.status)
 	}
 
-	r := ioutil.NopCloser(bytes.NewReader([]byte(h.response)))
+	r := io.NopCloser(bytes.NewReader([]byte(h.response)))
 	return &http.Response{
 		StatusCode: h.status,
 		Body:       r,

--- a/backend/version/meta.go
+++ b/backend/version/meta.go
@@ -1,7 +1,7 @@
 package version
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -16,7 +16,7 @@ func New() *PlatformVersion {
 }
 
 func (v *PlatformVersion) Get() (string, error) {
-	content, err := ioutil.ReadFile("/snap/platform/current/META/version")
+	content, err := os.ReadFile("/snap/platform/current/META/version")
 	if err != nil {
 		return "", err
 	}

--- a/integration/api/api.go
+++ b/integration/api/api.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -37,7 +36,7 @@ func do(method string, url string, data url.Values) (*string, error) {
 		return nil, err
 	}
 
-	bodyBytes, err := ioutil.ReadAll(responseString.Body)
+	bodyBytes, err := io.ReadAll(responseString.Body)
 	if err != nil {
 		log.Println(err)
 		return nil, err


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir`
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

`ioutil.TempDir` in `*_test.go` files can be replaced with `t.TempDir` from the `testing` package. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir