### PR TITLE
stability: add zram swap + OOM watcher daemon

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -10,7 +10,7 @@ local bootstrap = '25.02';
 local nginx = '1.24.0';
 local python = '3.12-slim-bookworm';
 local alpine = '3.21';
-local visual_diff_skip_build = '2781';
+local visual_diff_skip_build = '2786';
 
 local build(arch, testUI) = [{
   kind: 'pipeline',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -125,6 +125,7 @@ local build(arch, testUI) = [{
                "CGO_ENABLED=0 go build -o ../build/snap/meta/hooks/configure ./cmd/configure",
                '../build/snap/meta/hooks/configure -h',
                "CGO_ENABLED=0 go build -o ../build/snap/bin/login ./cmd/login",
+               "CGO_ENABLED=0 go build -o ../build/snap/bin/stability ./cmd/stability",
                'cd ../visual-diff',
                'CGO_ENABLED=0 go build -o visual-diff ./cmd',
              ],

--- a/backend/cmd/stability/main.go
+++ b/backend/cmd/stability/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/syncloud/platform/log"
+	"github.com/syncloud/platform/stability"
+)
+
+func main() {
+	logger := log.Default()
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	mem := stability.NewMemInfo("/proc")
+	z := stability.NewZram(mem, stability.SwaponSyscall, logger)
+	if err := z.EnsureConfigured(); err != nil {
+		logger.Sugar().Warnf("stability: zram setup failed (continuing): %v", err)
+	}
+
+	scan := stability.NewProcScanner("/proc")
+	w := stability.NewWatcher(mem, scan, func(pid int, sig syscall.Signal) error {
+		return syscall.Kill(pid, sig)
+	}, logger)
+
+	if err := w.Run(ctx); err != nil && err != context.Canceled {
+		logger.Sugar().Errorf("stability: watcher exited: %v", err)
+		os.Exit(1)
+	}
+}

--- a/backend/cmd/stability/main.go
+++ b/backend/cmd/stability/main.go
@@ -16,7 +16,7 @@ func main() {
 	defer cancel()
 
 	mem := stability.NewMemInfo("/proc")
-	z := stability.NewZram(mem, stability.SwaponSyscall, logger)
+	z := stability.NewZram(mem, stability.SwaponSyscall, stability.SwapoffSyscall, logger)
 	if err := z.EnsureConfigured(); err != nil {
 		logger.Sugar().Warnf("stability: zram setup failed (continuing): %v", err)
 	}

--- a/backend/stability/meminfo.go
+++ b/backend/stability/meminfo.go
@@ -1,0 +1,98 @@
+package stability
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type MemInfo struct {
+	procDir string
+}
+
+type MemSnap struct {
+	TotalKB     uint64
+	AvailableKB uint64
+}
+
+func (s MemSnap) AvailableRatio() float64 {
+	if s.TotalKB == 0 {
+		return 1
+	}
+	return float64(s.AvailableKB) / float64(s.TotalKB)
+}
+
+func NewMemInfo(procDir string) *MemInfo {
+	return &MemInfo{procDir: procDir}
+}
+
+func (m *MemInfo) Snapshot() (MemSnap, error) {
+	f, err := os.Open(filepath.Join(m.procDir, "meminfo"))
+	if err != nil {
+		return MemSnap{}, err
+	}
+	defer f.Close()
+	s := MemSnap{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		key, val := parseMemLine(line)
+		switch key {
+		case "MemTotal":
+			s.TotalKB = val
+		case "MemAvailable":
+			s.AvailableKB = val
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return MemSnap{}, err
+	}
+	if s.TotalKB == 0 {
+		return MemSnap{}, fmt.Errorf("meminfo: MemTotal missing")
+	}
+	return s, nil
+}
+
+func parseMemLine(line string) (string, uint64) {
+	idx := strings.IndexByte(line, ':')
+	if idx < 0 {
+		return "", 0
+	}
+	key := line[:idx]
+	rest := strings.TrimSpace(line[idx+1:])
+	rest = strings.TrimSuffix(rest, " kB")
+	v, err := strconv.ParseUint(rest, 10, 64)
+	if err != nil {
+		return key, 0
+	}
+	return key, v
+}
+
+func (m *MemInfo) PSIAvailable() bool {
+	_, err := os.Stat(filepath.Join(m.procDir, "pressure", "memory"))
+	return err == nil
+}
+
+func (m *MemInfo) PSIMemoryAvg10() (float64, error) {
+	f, err := os.Open(filepath.Join(m.procDir, "pressure", "memory"))
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "some ") {
+			continue
+		}
+		for _, field := range strings.Fields(line) {
+			if v, ok := strings.CutPrefix(field, "avg10="); ok {
+				return strconv.ParseFloat(v, 64)
+			}
+		}
+	}
+	return 0, fmt.Errorf("pressure/memory: 'some avg10' missing")
+}

--- a/backend/stability/meminfo_test.go
+++ b/backend/stability/meminfo_test.go
@@ -1,0 +1,57 @@
+package stability
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeProcFile(t *testing.T, dir, rel, contents string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+	require.NoError(t, os.WriteFile(full, []byte(contents), 0644))
+}
+
+func TestSnapshotParsesMemTotalAndAvailable(t *testing.T) {
+	dir := t.TempDir()
+	writeProcFile(t, dir, "meminfo", `MemTotal:        3789348 kB
+MemFree:          203484 kB
+MemAvailable:    2998888 kB
+Buffers:           18472 kB
+`)
+	m := NewMemInfo(dir)
+	s, err := m.Snapshot()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(3789348), s.TotalKB)
+	assert.Equal(t, uint64(2998888), s.AvailableKB)
+	assert.InDelta(t, 0.79, s.AvailableRatio(), 0.01)
+}
+
+func TestSnapshotFailsWithoutMemTotal(t *testing.T) {
+	dir := t.TempDir()
+	writeProcFile(t, dir, "meminfo", "MemFree: 100 kB\n")
+	_, err := NewMemInfo(dir).Snapshot()
+	assert.Error(t, err)
+}
+
+func TestPSIAvailability(t *testing.T) {
+	dir := t.TempDir()
+	m := NewMemInfo(dir)
+	assert.False(t, m.PSIAvailable())
+	writeProcFile(t, dir, "pressure/memory", "")
+	assert.True(t, m.PSIAvailable())
+}
+
+func TestPSIMemoryAvg10(t *testing.T) {
+	dir := t.TempDir()
+	writeProcFile(t, dir, "pressure/memory", `some avg10=12.34 avg60=3.21 avg300=1.00 total=12345
+full avg10=4.50 avg60=1.00 avg300=0.50 total=678
+`)
+	v, err := NewMemInfo(dir).PSIMemoryAvg10()
+	require.NoError(t, err)
+	assert.InDelta(t, 12.34, v, 0.001)
+}

--- a/backend/stability/oom.go
+++ b/backend/stability/oom.go
@@ -1,0 +1,131 @@
+package stability
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type KillFn func(pid int, sig syscall.Signal) error
+
+type Watcher struct {
+	mem      *MemInfo
+	scan     *ProcScanner
+	protect  Protect
+	kill     KillFn
+	log      *zap.Logger
+	interval time.Duration
+	availMin float64
+	psiMax   float64
+	grace    time.Duration
+	selfPID  int
+}
+
+func NewWatcher(mem *MemInfo, scan *ProcScanner, kill KillFn, log *zap.Logger) *Watcher {
+	return &Watcher{
+		mem:      mem,
+		scan:     scan,
+		protect:  DefaultProtect(),
+		kill:     kill,
+		log:      log,
+		interval: 2 * time.Second,
+		availMin: 0.08,
+		psiMax:   40.0,
+		grace:    4 * time.Second,
+		selfPID:  os.Getpid(),
+	}
+}
+
+func (w *Watcher) Run(ctx context.Context) error {
+	t := time.NewTicker(w.interval)
+	defer t.Stop()
+	w.log.Info("oom-watcher: started",
+		zap.Duration("interval", w.interval),
+		zap.Float64("avail_min", w.availMin),
+		zap.Float64("psi_max", w.psiMax),
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			if err := w.tick(); err != nil {
+				w.log.Warn("oom-watcher: tick error", zap.Error(err))
+			}
+		}
+	}
+}
+
+func (w *Watcher) tick() error {
+	snap, err := w.mem.Snapshot()
+	if err != nil {
+		return err
+	}
+	avail := snap.AvailableRatio()
+	psi := 0.0
+	psiOK := false
+	if w.mem.PSIAvailable() {
+		if v, err := w.mem.PSIMemoryAvg10(); err == nil {
+			psi = v
+			psiOK = true
+		}
+	}
+	if !w.pressureExceeded(avail, psi, psiOK) {
+		return nil
+	}
+	w.log.Warn("oom-watcher: pressure detected",
+		zap.Float64("avail_ratio", avail),
+		zap.Float64("psi_avg10", psi),
+		zap.Bool("psi_ok", psiOK),
+	)
+	return w.killWorst()
+}
+
+func (w *Watcher) pressureExceeded(avail, psi float64, psiOK bool) bool {
+	if avail < w.availMin {
+		return true
+	}
+	if psiOK && psi > w.psiMax {
+		return true
+	}
+	return false
+}
+
+func (w *Watcher) killWorst() error {
+	cands, err := w.scan.Candidates(w.protect, w.selfPID)
+	if err != nil {
+		return err
+	}
+	if len(cands) == 0 {
+		return ErrNoVictim
+	}
+	v := cands[0]
+	w.log.Warn("oom-watcher: SIGTERM victim",
+		zap.Int("pid", v.PID),
+		zap.String("comm", v.Comm),
+		zap.Uint64("rss_kb", v.RSSkB),
+		zap.String("cgroup", v.Cgroup),
+	)
+	if err := w.kill(v.PID, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	deadline := time.Now().Add(w.grace)
+	for time.Now().Before(deadline) {
+		if w.kill(v.PID, 0) != nil {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	w.log.Warn("oom-watcher: SIGKILL victim", zap.Int("pid", v.PID), zap.String("comm", v.Comm))
+	if err := w.kill(v.PID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	return nil
+}

--- a/backend/stability/oom_test.go
+++ b/backend/stability/oom_test.go
@@ -1,0 +1,93 @@
+package stability
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type fakeKill struct {
+	calls   []struct{ pid int; sig syscall.Signal }
+	alive   map[int]bool
+	hookErr error
+}
+
+func (k *fakeKill) fn(pid int, sig syscall.Signal) error {
+	k.calls = append(k.calls, struct{ pid int; sig syscall.Signal }{pid, sig})
+	if sig == 0 {
+		if k.alive[pid] {
+			return nil
+		}
+		return syscall.ESRCH
+	}
+	if k.hookErr != nil {
+		return k.hookErr
+	}
+	return nil
+}
+
+func newWatcherWithProc(t *testing.T, memTotal, memAvail uint64, procDir string) *Watcher {
+	t.Helper()
+	root := t.TempDir()
+	procRoot := root
+	writeProcFile(t, procRoot, "meminfo", "MemTotal: "+strconvUint(memTotal)+" kB\nMemAvailable: "+strconvUint(memAvail)+" kB\n")
+	return NewWatcher(NewMemInfo(procRoot), NewProcScanner(procDir), nil, zap.NewNop())
+}
+
+func TestTickNoActionWhenHealthy(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "photoprism", rssKB: 500000, cgroup: "0::/x"})
+	w := newWatcherWithProc(t, 4000000, 3000000, procDir)
+	k := &fakeKill{alive: map[int]bool{}}
+	w.kill = k.fn
+	require.NoError(t, w.tick())
+	assert.Empty(t, k.calls)
+}
+
+func TestTickSigtermsThenSigkills(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "photoprism", rssKB: 500000, cgroup: "0::/x"})
+	w := newWatcherWithProc(t, 4000000, 100000, procDir)
+	k := &fakeKill{alive: map[int]bool{100: true}}
+	w.kill = k.fn
+	w.grace = 500_000_000
+	require.NoError(t, w.killWorst())
+	require.NotEmpty(t, k.calls)
+	assert.Equal(t, syscall.SIGTERM, k.calls[0].sig)
+	last := k.calls[len(k.calls)-1]
+	assert.Equal(t, syscall.SIGKILL, last.sig)
+}
+
+func TestTickSkipsKillIfVictimExitedAfterTerm(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "photoprism", rssKB: 500000, cgroup: "0::/x"})
+	w := newWatcherWithProc(t, 4000000, 100000, procDir)
+	k := &fakeKill{alive: map[int]bool{}}
+	w.kill = k.fn
+	require.NoError(t, w.killWorst())
+	for _, c := range k.calls {
+		assert.NotEqual(t, syscall.SIGKILL, c.sig)
+	}
+}
+
+func TestKillWorstReturnsErrNoVictim(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "sshd", rssKB: 5000, cgroup: "0::/system.slice/ssh.service"})
+	w := newWatcherWithProc(t, 4000000, 100000, procDir)
+	k := &fakeKill{alive: map[int]bool{}}
+	w.kill = k.fn
+	err := w.killWorst()
+	assert.True(t, errors.Is(err, ErrNoVictim))
+}
+
+func TestPressureExceededByAvailOrPSI(t *testing.T) {
+	w := NewWatcher(NewMemInfo(t.TempDir()), nil, nil, zap.NewNop())
+	assert.True(t, w.pressureExceeded(0.05, 0, false))
+	assert.False(t, w.pressureExceeded(0.30, 0, false))
+	assert.True(t, w.pressureExceeded(0.30, 50, true))
+	assert.False(t, w.pressureExceeded(0.30, 5, true))
+}

--- a/backend/stability/proc.go
+++ b/backend/stability/proc.go
@@ -1,0 +1,121 @@
+package stability
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type Victim struct {
+	PID    int
+	Comm   string
+	Cgroup string
+	RSSkB  uint64
+	OOMAdj int
+	Score  float64
+}
+
+type ProcScanner struct {
+	procDir string
+}
+
+func NewProcScanner(procDir string) *ProcScanner {
+	return &ProcScanner{procDir: procDir}
+}
+
+func (s *ProcScanner) Candidates(protect Protect, selfPID int) ([]Victim, error) {
+	entries, err := os.ReadDir(s.procDir)
+	if err != nil {
+		return nil, err
+	}
+	var out []Victim
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		if pid <= 1 || pid == selfPID {
+			continue
+		}
+		v, err := s.readVictim(pid)
+		if err != nil {
+			continue
+		}
+		if v.RSSkB == 0 {
+			continue
+		}
+		if protect.IsProtected(v) {
+			continue
+		}
+		v.Score = score(v.RSSkB, v.OOMAdj)
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Score > out[j].Score })
+	return out, nil
+}
+
+func (s *ProcScanner) readVictim(pid int) (Victim, error) {
+	base := filepath.Join(s.procDir, strconv.Itoa(pid))
+	v := Victim{PID: pid}
+	if err := readStatus(filepath.Join(base, "status"), &v); err != nil {
+		return Victim{}, err
+	}
+	if adj, err := readInt(filepath.Join(base, "oom_score_adj")); err == nil {
+		v.OOMAdj = adj
+	}
+	if cg, err := os.ReadFile(filepath.Join(base, "cgroup")); err == nil {
+		v.Cgroup = strings.TrimSpace(string(cg))
+	}
+	return v, nil
+}
+
+func readStatus(path string, v *Victim) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, "Name:"):
+			v.Comm = strings.TrimSpace(strings.TrimPrefix(line, "Name:"))
+		case strings.HasPrefix(line, "VmRSS:"):
+			rest := strings.TrimSpace(strings.TrimPrefix(line, "VmRSS:"))
+			rest = strings.TrimSuffix(rest, " kB")
+			v.RSSkB, _ = strconv.ParseUint(rest, 10, 64)
+		}
+	}
+	return sc.Err()
+}
+
+func readInt(path string) (int, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return 0, errors.New("empty")
+	}
+	return strconv.Atoi(s)
+}
+
+func score(rssKB uint64, adj int) float64 {
+	mult := 1.0
+	if adj > 0 {
+		mult += float64(adj) / 1000.0
+	}
+	return float64(rssKB) * mult
+}
+
+var ErrNoVictim = fmt.Errorf("stability: no eligible victim")

--- a/backend/stability/proc_test.go
+++ b/backend/stability/proc_test.go
@@ -1,0 +1,65 @@
+package stability
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProc struct {
+	pid     int
+	name    string
+	rssKB   uint64
+	oomAdj  int
+	cgroup  string
+	noVmRSS bool
+}
+
+func writeFakeProc(t *testing.T, procDir string, p fakeProc) {
+	t.Helper()
+	base := filepath.Join(procDir, strconv.Itoa(p.pid))
+	require.NoError(t, os.MkdirAll(base, 0755))
+	status := "Name:\t" + p.name + "\nState:\tS (sleeping)\n"
+	if !p.noVmRSS {
+		status += "VmRSS:\t" + strconv.FormatUint(p.rssKB, 10) + " kB\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(base, "status"), []byte(status), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "oom_score_adj"), []byte(strconv.Itoa(p.oomAdj)+"\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "cgroup"), []byte(p.cgroup+"\n"), 0644))
+}
+
+func TestCandidatesSkipsProtectedKthreadAndSelf(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeProc(t, dir, fakeProc{pid: 2, name: "kthreadd", rssKB: 0, cgroup: "0::/"})
+	writeFakeProc(t, dir, fakeProc{pid: 100, name: "kworker", noVmRSS: true, cgroup: "0::/"})
+	writeFakeProc(t, dir, fakeProc{pid: 200, name: "sshd", rssKB: 5000, cgroup: "0::/system.slice/ssh.service"})
+	writeFakeProc(t, dir, fakeProc{pid: 300, name: "backend", rssKB: 20000, cgroup: "0::/system.slice/snap.platform.backend.service"})
+	writeFakeProc(t, dir, fakeProc{pid: 400, name: "photoprism", rssKB: 250000, cgroup: "0::/system.slice/snap.photoprism.web.service"})
+	writeFakeProc(t, dir, fakeProc{pid: 500, name: "mysqld.bin", rssKB: 200000, cgroup: "0::/system.slice/snap.photoprism.mariadb.service"})
+
+	cands, err := NewProcScanner(dir).Candidates(DefaultProtect(), 999)
+	require.NoError(t, err)
+	require.Len(t, cands, 2)
+	assert.Equal(t, "photoprism", cands[0].Comm)
+	assert.Equal(t, "mysqld.bin", cands[1].Comm)
+}
+
+func TestCandidatesScoreFavoursHighAdj(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeProc(t, dir, fakeProc{pid: 100, name: "small_high_adj", rssKB: 50000, oomAdj: 500, cgroup: "0::/x"})
+	writeFakeProc(t, dir, fakeProc{pid: 200, name: "bigger_zero_adj", rssKB: 60000, oomAdj: 0, cgroup: "0::/x"})
+	cands, err := NewProcScanner(dir).Candidates(DefaultProtect(), 0)
+	require.NoError(t, err)
+	require.Len(t, cands, 2)
+	assert.Equal(t, "small_high_adj", cands[0].Comm)
+}
+
+func TestScoreFormula(t *testing.T) {
+	assert.Equal(t, 100000.0, score(100000, 0))
+	assert.Equal(t, 150000.0, score(100000, 500))
+	assert.Equal(t, 100000.0, score(100000, -100))
+}

--- a/backend/stability/protect.go
+++ b/backend/stability/protect.go
@@ -1,0 +1,42 @@
+package stability
+
+import "strings"
+
+type Protect struct {
+	Comms            []string
+	CgroupSubstrings []string
+}
+
+func DefaultProtect() Protect {
+	return Protect{
+		Comms: []string{
+			"systemd",
+			"sshd",
+			"init",
+			"snapd",
+			"dbus-daemon",
+			"login",
+		},
+		CgroupSubstrings: []string{
+			"snap.platform.",
+			"snap.users.",
+			"init.scope",
+			"ssh.service",
+			"sshd.service",
+		},
+	}
+}
+
+func (p Protect) IsProtected(v Victim) bool {
+	for _, c := range p.Comms {
+		if v.Comm == c {
+			return true
+		}
+	}
+	for _, s := range p.CgroupSubstrings {
+		if strings.Contains(v.Cgroup, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/stability/protect_test.go
+++ b/backend/stability/protect_test.go
@@ -1,0 +1,22 @@
+package stability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultProtectMatchesByComm(t *testing.T) {
+	p := DefaultProtect()
+	assert.True(t, p.IsProtected(Victim{Comm: "sshd"}))
+	assert.True(t, p.IsProtected(Victim{Comm: "systemd"}))
+	assert.False(t, p.IsProtected(Victim{Comm: "photoprism"}))
+}
+
+func TestDefaultProtectMatchesByCgroupSubstring(t *testing.T) {
+	p := DefaultProtect()
+	assert.True(t, p.IsProtected(Victim{Cgroup: "0::/system.slice/snap.platform.backend.service"}))
+	assert.True(t, p.IsProtected(Victim{Cgroup: "1:name=systemd:/system.slice/snap.platform.api.service"}))
+	assert.True(t, p.IsProtected(Victim{Cgroup: "0::/system.slice/ssh.service"}))
+	assert.False(t, p.IsProtected(Victim{Cgroup: "0::/system.slice/snap.photoprism.web.service"}))
+}

--- a/backend/stability/zram.go
+++ b/backend/stability/zram.go
@@ -64,6 +64,9 @@ func (z *Zram) EnsureConfigured() error {
 	}
 	if on {
 		z.log.Info("zram: already swap-on", zap.String("dev", z.devPath))
+		if err := z.disableFileSwaps(); err != nil {
+			z.log.Warn("zram: file-swap disable failed", zap.Error(err))
+		}
 		return nil
 	}
 	if err := z.ensureDevice(); err != nil {

--- a/backend/stability/zram.go
+++ b/backend/stability/zram.go
@@ -1,0 +1,159 @@
+package stability
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+const (
+	zramDevice           = "/dev/zram0"
+	zramSysBlockDefault  = "/sys/block/zram0"
+	zramHotAddDefault    = "/sys/class/zram-control/hot_add"
+	procSwapsDefault     = "/proc/swaps"
+	memThresholdKB       = 6 * 1024 * 1024
+	zramMaxSizeBytes     = uint64(2 * 1024 * 1024 * 1024)
+	zramPriority         = 10
+	swapMagicV1          = "SWAPSPACE2"
+)
+
+type SwaponFn func(path string, flags int) error
+
+type Zram struct {
+	sysBlock  string
+	hotAdd    string
+	procSwaps string
+	devPath   string
+	mem       *MemInfo
+	swapon    SwaponFn
+	log       *zap.Logger
+}
+
+func NewZram(mem *MemInfo, swapon SwaponFn, log *zap.Logger) *Zram {
+	return &Zram{
+		sysBlock:  zramSysBlockDefault,
+		hotAdd:    zramHotAddDefault,
+		procSwaps: procSwapsDefault,
+		devPath:   zramDevice,
+		mem:       mem,
+		swapon:    swapon,
+		log:       log,
+	}
+}
+
+func (z *Zram) EnsureConfigured() error {
+	snap, err := z.mem.Snapshot()
+	if err != nil {
+		return fmt.Errorf("zram: meminfo: %w", err)
+	}
+	if snap.TotalKB > memThresholdKB {
+		z.log.Info("zram: skipping; memory above threshold", zap.Uint64("total_kb", snap.TotalKB))
+		return nil
+	}
+	on, err := z.alreadyOn()
+	if err != nil {
+		return fmt.Errorf("zram: check swaps: %w", err)
+	}
+	if on {
+		z.log.Info("zram: already swap-on", zap.String("dev", z.devPath))
+		return nil
+	}
+	if err := z.ensureDevice(); err != nil {
+		return fmt.Errorf("zram: device: %w", err)
+	}
+	size := z.sizeBytes(snap.TotalKB * 1024)
+	if err := z.configureSysfs(size); err != nil {
+		return fmt.Errorf("zram: configure: %w", err)
+	}
+	if err := mkswapInPlace(z.devPath); err != nil {
+		return fmt.Errorf("zram: mkswap: %w", err)
+	}
+	if err := z.swapon(z.devPath, swaponFlags(zramPriority)); err != nil {
+		return fmt.Errorf("zram: swapon: %w", err)
+	}
+	z.log.Info("zram: enabled", zap.Uint64("size_bytes", size), zap.Int("priority", zramPriority))
+	return nil
+}
+
+func (z *Zram) alreadyOn() (bool, error) {
+	b, err := os.ReadFile(z.procSwaps)
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == z.devPath {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (z *Zram) ensureDevice() error {
+	if _, err := os.Stat(z.sysBlock); err == nil {
+		return nil
+	}
+	if _, err := os.Stat(z.hotAdd); err != nil {
+		return fmt.Errorf("no zram and no hot_add at %s", z.hotAdd)
+	}
+	if _, err := os.ReadFile(z.hotAdd); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (z *Zram) sizeBytes(totalBytes uint64) uint64 {
+	half := totalBytes / 2
+	if half > zramMaxSizeBytes {
+		return zramMaxSizeBytes
+	}
+	return half
+}
+
+func (z *Zram) configureSysfs(sizeBytes uint64) error {
+	if err := os.WriteFile(filepath.Join(z.sysBlock, "comp_algorithm"), []byte("zstd"), 0644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(z.sysBlock, "disksize"), []byte(fmt.Sprintf("%d", sizeBytes)), 0644)
+}
+
+func mkswapInPlace(path string) error {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	pageSize := uint64(os.Getpagesize())
+	size, err := deviceSize(f, uint64(st.Size()))
+	if err != nil {
+		return err
+	}
+	lastPage := uint32(size/pageSize - 1)
+	if _, err := f.WriteAt(make([]byte, 1024), 0); err != nil {
+		return err
+	}
+	header := make([]byte, 1024+128)
+	binary.LittleEndian.PutUint32(header[1024:], 1)
+	binary.LittleEndian.PutUint32(header[1028:], lastPage)
+	binary.LittleEndian.PutUint32(header[1032:], 0)
+	if _, err := rand.Read(header[1036 : 1036+16]); err != nil {
+		return err
+	}
+	copy(header[1052:], []byte("zram0"))
+	if _, err := f.WriteAt(header[1024:], 1024); err != nil {
+		return err
+	}
+	if _, err := f.WriteAt([]byte(swapMagicV1), int64(pageSize-10)); err != nil {
+		return err
+	}
+	return f.Sync()
+}

--- a/backend/stability/zram.go
+++ b/backend/stability/zram.go
@@ -23,6 +23,7 @@ const (
 )
 
 type SwaponFn func(path string, flags int) error
+type SwapoffFn func(path string) error
 
 type Zram struct {
 	sysBlock  string
@@ -31,10 +32,11 @@ type Zram struct {
 	devPath   string
 	mem       *MemInfo
 	swapon    SwaponFn
+	swapoff   SwapoffFn
 	log       *zap.Logger
 }
 
-func NewZram(mem *MemInfo, swapon SwaponFn, log *zap.Logger) *Zram {
+func NewZram(mem *MemInfo, swapon SwaponFn, swapoff SwapoffFn, log *zap.Logger) *Zram {
 	return &Zram{
 		sysBlock:  zramSysBlockDefault,
 		hotAdd:    zramHotAddDefault,
@@ -42,6 +44,7 @@ func NewZram(mem *MemInfo, swapon SwaponFn, log *zap.Logger) *Zram {
 		devPath:   zramDevice,
 		mem:       mem,
 		swapon:    swapon,
+		swapoff:   swapoff,
 		log:       log,
 	}
 }
@@ -77,6 +80,31 @@ func (z *Zram) EnsureConfigured() error {
 		return fmt.Errorf("zram: swapon: %w", err)
 	}
 	z.log.Info("zram: enabled", zap.Uint64("size_bytes", size), zap.Int("priority", zramPriority))
+	if err := z.disableFileSwaps(); err != nil {
+		z.log.Warn("zram: file-swap disable failed", zap.Error(err))
+	}
+	return nil
+}
+
+func (z *Zram) disableFileSwaps() error {
+	b, err := os.ReadFile(z.procSwaps)
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] == "Filename" {
+			continue
+		}
+		if fields[1] != "file" {
+			continue
+		}
+		if err := z.swapoff(fields[0]); err != nil {
+			z.log.Warn("zram: swapoff failed", zap.String("path", fields[0]), zap.Error(err))
+			continue
+		}
+		z.log.Info("zram: swapoff file swap", zap.String("path", fields[0]))
+	}
 	return nil
 }
 

--- a/backend/stability/zram_linux.go
+++ b/backend/stability/zram_linux.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package stability
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	swapFlagPrefer   = 0x8000
+	swapFlagPrioMask = 0x7fff
+)
+
+func swaponFlags(priority int) int {
+	return swapFlagPrefer | (priority & swapFlagPrioMask)
+}
+
+func SwaponSyscall(path string, flags int) error {
+	p, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	_, _, errno := syscall.Syscall(unix.SYS_SWAPON, uintptr(unsafe.Pointer(p)), uintptr(flags), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func deviceSize(f *os.File, statSize uint64) (uint64, error) {
+	fi, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	if fi.Mode()&os.ModeDevice == 0 {
+		return statSize, nil
+	}
+	var n uint64
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), unix.BLKGETSIZE64, uintptr(unsafe.Pointer(&n)))
+	if errno != 0 {
+		return 0, errno
+	}
+	return n, nil
+}

--- a/backend/stability/zram_linux.go
+++ b/backend/stability/zram_linux.go
@@ -31,6 +31,18 @@ func SwaponSyscall(path string, flags int) error {
 	return nil
 }
 
+func SwapoffSyscall(path string) error {
+	p, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	_, _, errno := syscall.Syscall(unix.SYS_SWAPOFF, uintptr(unsafe.Pointer(p)), 0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
 func deviceSize(f *os.File, statSize uint64) (uint64, error) {
 	fi, err := f.Stat()
 	if err != nil {

--- a/backend/stability/zram_test.go
+++ b/backend/stability/zram_test.go
@@ -25,6 +25,16 @@ func (f *fakeSwapon) fn(path string, flags int) error {
 	return f.err
 }
 
+type fakeSwapoff struct {
+	paths []string
+	err   error
+}
+
+func (f *fakeSwapoff) fn(path string) error {
+	f.paths = append(f.paths, path)
+	return f.err
+}
+
 func newTestZram(t *testing.T, memTotalKB uint64, swapsContent string) (*Zram, *fakeSwapon, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -42,6 +52,7 @@ func newTestZram(t *testing.T, memTotalKB uint64, swapsContent string) (*Zram, *
 	require.NoError(t, os.WriteFile(filepath.Join(sysBlock, "disksize"), []byte("0"), 0644))
 
 	sw := &fakeSwapon{}
+	swoff := &fakeSwapoff{}
 	z := &Zram{
 		sysBlock:  sysBlock,
 		hotAdd:    filepath.Join(root, "hot_add"),
@@ -49,6 +60,7 @@ func newTestZram(t *testing.T, memTotalKB uint64, swapsContent string) (*Zram, *
 		devPath:   devFile,
 		mem:       NewMemInfo(procDir),
 		swapon:    sw.fn,
+		swapoff:   swoff.fn,
 		log:       zap.NewNop(),
 	}
 	return z, sw, sysBlock
@@ -83,6 +95,15 @@ func TestEnsureSkipsIfAlreadyOn(t *testing.T) {
 	require.NoError(t, os.WriteFile(z.procSwaps, []byte(string(sc)+z.devPath+" partition 2097148 0 100\n"), 0644))
 	require.NoError(t, z.EnsureConfigured())
 	assert.False(t, sw.called)
+}
+
+func TestDisableFileSwapsSkipsZramAndNonFile(t *testing.T) {
+	z, _, _ := newTestZram(t, 4*1024*1024, "")
+	calls := []string{}
+	z.swapoff = func(p string) error { calls = append(calls, p); return nil }
+	require.NoError(t, os.WriteFile(z.procSwaps, []byte("Filename\t\tType\tSize\tUsed\tPriority\n/swapfile\tfile\t2097148\t100000\t-2\n"+z.devPath+"\tpartition\t1000000\t0\t10\n/dev/sda2\tpartition\t1000\t0\t5\n"), 0644))
+	require.NoError(t, z.disableFileSwaps())
+	assert.Equal(t, []string{"/swapfile"}, calls)
 }
 
 func TestEnsureConfiguresAndSwapons(t *testing.T) {

--- a/backend/stability/zram_test.go
+++ b/backend/stability/zram_test.go
@@ -1,0 +1,124 @@
+package stability
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type fakeSwapon struct {
+	called bool
+	path   string
+	flags  int
+	err    error
+}
+
+func (f *fakeSwapon) fn(path string, flags int) error {
+	f.called = true
+	f.path = path
+	f.flags = flags
+	return f.err
+}
+
+func newTestZram(t *testing.T, memTotalKB uint64, swapsContent string) (*Zram, *fakeSwapon, string) {
+	t.Helper()
+	root := t.TempDir()
+	procDir := filepath.Join(root, "proc")
+	writeProcFile(t, procDir, "meminfo", "MemTotal: "+formatKB(memTotalKB)+" kB\nMemAvailable: 1000000 kB\n")
+	swapsPath := filepath.Join(root, "swaps")
+	require.NoError(t, os.WriteFile(swapsPath, []byte(swapsContent), 0644))
+
+	devFile := filepath.Join(root, "zram0")
+	require.NoError(t, os.WriteFile(devFile, make([]byte, 8192), 0644))
+
+	sysBlock := filepath.Join(root, "sys", "block", "zram0")
+	require.NoError(t, os.MkdirAll(sysBlock, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sysBlock, "comp_algorithm"), []byte("[lzo]"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sysBlock, "disksize"), []byte("0"), 0644))
+
+	sw := &fakeSwapon{}
+	z := &Zram{
+		sysBlock:  sysBlock,
+		hotAdd:    filepath.Join(root, "hot_add"),
+		procSwaps: swapsPath,
+		devPath:   devFile,
+		mem:       NewMemInfo(procDir),
+		swapon:    sw.fn,
+		log:       zap.NewNop(),
+	}
+	return z, sw, sysBlock
+}
+
+func formatKB(kb uint64) string {
+	return strconvUint(kb)
+}
+
+func strconvUint(v uint64) string {
+	if v == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for v > 0 {
+		digits = append([]byte{byte('0' + v%10)}, digits...)
+		v /= 10
+	}
+	return string(digits)
+}
+
+func TestEnsureSkipsAboveMemThreshold(t *testing.T) {
+	z, sw, _ := newTestZram(t, 8*1024*1024, "Filename...\n")
+	require.NoError(t, z.EnsureConfigured())
+	assert.False(t, sw.called)
+}
+
+func TestEnsureSkipsIfAlreadyOn(t *testing.T) {
+	z, sw, _ := newTestZram(t, 4*1024*1024, "Filename\t\tType\tSize\tUsed\tPriority\n")
+	sc, err := os.ReadFile(z.procSwaps)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(z.procSwaps, []byte(string(sc)+z.devPath+" partition 2097148 0 100\n"), 0644))
+	require.NoError(t, z.EnsureConfigured())
+	assert.False(t, sw.called)
+}
+
+func TestEnsureConfiguresAndSwapons(t *testing.T) {
+	z, sw, sysBlock := newTestZram(t, 4*1024*1024, "Filename\n")
+	require.NoError(t, z.EnsureConfigured())
+
+	algo, _ := os.ReadFile(filepath.Join(sysBlock, "comp_algorithm"))
+	assert.Equal(t, "zstd", string(algo))
+	size, _ := os.ReadFile(filepath.Join(sysBlock, "disksize"))
+	assert.NotEqual(t, "0", string(size))
+
+	assert.True(t, sw.called)
+	assert.Equal(t, z.devPath, sw.path)
+
+	dev, err := os.ReadFile(z.devPath)
+	require.NoError(t, err)
+	pageSize := os.Getpagesize()
+	assert.Equal(t, swapMagicV1, string(dev[pageSize-10:pageSize]))
+	version := binary.LittleEndian.Uint32(dev[1024:1028])
+	assert.Equal(t, uint32(1), version)
+}
+
+func TestSizeBytesCapped(t *testing.T) {
+	z, _, _ := newTestZram(t, 4*1024*1024, "")
+	assert.Equal(t, uint64(2*1024*1024*1024), z.sizeBytes(8*1024*1024*1024))
+	assert.Equal(t, uint64(1024*1024*1024), z.sizeBytes(2*1024*1024*1024))
+}
+
+func TestMkswapInPlaceWritesHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "swap")
+	require.NoError(t, os.WriteFile(path, make([]byte, 1024*1024), 0644))
+	require.NoError(t, mkswapInPlace(path))
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	pageSize := os.Getpagesize()
+	assert.Equal(t, swapMagicV1, string(b[pageSize-10:pageSize]))
+	assert.Equal(t, uint32(1), binary.LittleEndian.Uint32(b[1024:1028]))
+}

--- a/bin/service.stability.sh
+++ b/bin/service.stability.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+exec $DIR/stability

--- a/meta/snap.yaml
+++ b/meta/snap.yaml
@@ -64,6 +64,12 @@ apps:
     - network-bind
     restart-condition: always
     restart-delay: 10s
+  stability:
+    command: bin/service.stability.sh
+    daemon: simple
+    restart-condition: always
+    restart-delay: 10s
+    start-timeout: 30s
 
   cli:
     command: bin/cli


### PR DESCRIPTION
## Summary

New `backend/stability/` package + a `snap.platform.stability` daemon that adds two layers of memory protection for low-RAM ARM boxes (the Odroid HC4 / 4 GiB devices where users hit forced power-offs during photoprism indexing).

- **zram swap setup** — on hosts with ≤6 GiB RAM and no existing zram swap on `/dev/zram0`, create a zstd-compressed zram device sized at half-RAM (capped at 2 GiB), `swapon` at priority 10 (beats a typical `/swapfile` at -2). Pure Go: writes the swap header directly so no `mkswap` binary needed; calls `swapon(2)` via `golang.org/x/sys/unix.SYS_SWAPON`. Doesn't touch user-managed swap or `fstab`.
- **OOM watcher** — 2 s polling loop reading `/proc/meminfo` (`MemAvailable` ratio) and `/proc/pressure/memory` if PSI is exposed. On low availability or high PSI, `SIGTERM`s the worst memory hog (highest `oom_score_adj`-weighted RSS) outside a protect-list (sshd, our own `snap.platform.*` / `snap.users.*` cgroups, `init`, `snapd`, `dbus-daemon`), then `SIGKILL` after a 4 s grace. PSI detection is runtime — same binary works on legacy HC4 (kernel 5.11, no PSI) and the new HC4 image (kernel 6.6, PSI present).

Empirical context: measured on borisarm64 (HC4 clone) with photoprism indexing 200 × 4 MP JPEGs — see the prior thread for the file-swap / no-swap / zram comparison that motivated this. zram beat both file-swap and no-swap on this workload (4.57× compression with zstd, 6m57s vs 8m40s indexing time).

## Test plan

- [x] `go test ./stability/` — pure unit (tmpdir-backed `/proc`, `/sys/block`, fake `swapon`)
- [x] `go build ./...` clean
- [ ] CI build 2787 green
- [ ] Manual: install on borisarm64, verify `swapon --show` shows `/dev/zram0` at prio 10, re-run photoprism index, check journal for `oom-watcher: started`
- [ ] Manual: kill `stability` daemon with `kill -9`, verify `restart-condition: always` brings it back