### PR TITLE
stability: move events log from $SNAP_COMMON to $SNAP_DATA

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -10,7 +10,7 @@ local bootstrap = '25.02';
 local nginx = '1.24.0';
 local python = '3.12-slim-bookworm';
 local alpine = '3.21';
-local visual_diff_skip_build = '2786';
+local visual_diff_skip_build = '2837';
 
 local build(arch, testUI) = [{
   kind: 'pipeline',

--- a/backend/cmd/stability/main.go
+++ b/backend/cmd/stability/main.go
@@ -18,11 +18,11 @@ func main() {
 	mem := stability.NewMemInfo("/proc")
 	dataDir := os.Getenv("SNAP_DATA")
 	if dataDir == "" {
-		dataDir = "/var/snap/platform/current"
+		logger.Fatal("stability: SNAP_DATA not set")
 	}
 	commonDir := os.Getenv("SNAP_COMMON")
 	if commonDir == "" {
-		commonDir = "/var/snap/platform/common"
+		logger.Fatal("stability: SNAP_COMMON not set")
 	}
 	eventsPath := dataDir + "/stability-events.jsonl"
 	stability.MigrateEventLog(commonDir+"/stability-events.jsonl", eventsPath, logger)

--- a/backend/cmd/stability/main.go
+++ b/backend/cmd/stability/main.go
@@ -21,17 +21,17 @@ func main() {
 	eventsPath := path.Join(hook.DataDir, "stability-events.jsonl")
 	stability.MigrateEventLog(path.Join(hook.CommonDir, "stability-events.jsonl"), eventsPath, logger)
 	events := stability.NewEventLog(eventsPath)
-	z := stability.NewZram(mem, stability.SwaponSyscall, stability.SwapoffSyscall, events, logger)
-	if err := z.EnsureConfigured(); err != nil {
+	zram := stability.NewZram(mem, stability.SwaponSyscall, stability.SwapoffSyscall, events, logger)
+	if err := zram.EnsureConfigured(); err != nil {
 		logger.Sugar().Warnf("stability: zram setup failed (continuing): %v", err)
 	}
 
-	scan := stability.NewProcScanner("/proc")
-	w := stability.NewWatcher(mem, scan, func(pid int, sig syscall.Signal) error {
+	scanner := stability.NewProcScanner("/proc")
+	watcher := stability.NewWatcher(mem, scanner, func(pid int, sig syscall.Signal) error {
 		return syscall.Kill(pid, sig)
 	}, events, logger)
 
-	if err := w.Run(ctx); err != nil && err != context.Canceled {
+	if err := watcher.Run(ctx); err != nil && err != context.Canceled {
 		logger.Sugar().Errorf("stability: watcher exited: %v", err)
 		os.Exit(1)
 	}

--- a/backend/cmd/stability/main.go
+++ b/backend/cmd/stability/main.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"path"
 	"syscall"
 
+	"github.com/syncloud/platform/hook"
 	"github.com/syncloud/platform/log"
 	"github.com/syncloud/platform/stability"
 )
@@ -16,16 +18,8 @@ func main() {
 	defer cancel()
 
 	mem := stability.NewMemInfo("/proc")
-	dataDir := os.Getenv("SNAP_DATA")
-	if dataDir == "" {
-		logger.Fatal("stability: SNAP_DATA not set")
-	}
-	commonDir := os.Getenv("SNAP_COMMON")
-	if commonDir == "" {
-		logger.Fatal("stability: SNAP_COMMON not set")
-	}
-	eventsPath := dataDir + "/stability-events.jsonl"
-	stability.MigrateEventLog(commonDir+"/stability-events.jsonl", eventsPath, logger)
+	eventsPath := path.Join(hook.DataDir, "stability-events.jsonl")
+	stability.MigrateEventLog(path.Join(hook.CommonDir, "stability-events.jsonl"), eventsPath, logger)
 	events := stability.NewEventLog(eventsPath)
 	z := stability.NewZram(mem, stability.SwaponSyscall, stability.SwapoffSyscall, events, logger)
 	if err := z.EnsureConfigured(); err != nil {

--- a/backend/cmd/stability/main.go
+++ b/backend/cmd/stability/main.go
@@ -16,11 +16,17 @@ func main() {
 	defer cancel()
 
 	mem := stability.NewMemInfo("/proc")
+	dataDir := os.Getenv("SNAP_DATA")
+	if dataDir == "" {
+		dataDir = "/var/snap/platform/current"
+	}
 	commonDir := os.Getenv("SNAP_COMMON")
 	if commonDir == "" {
 		commonDir = "/var/snap/platform/common"
 	}
-	events := stability.NewEventLog(commonDir + "/stability-events.jsonl")
+	eventsPath := dataDir + "/stability-events.jsonl"
+	stability.MigrateEventLog(commonDir+"/stability-events.jsonl", eventsPath, logger)
+	events := stability.NewEventLog(eventsPath)
 	z := stability.NewZram(mem, stability.SwaponSyscall, stability.SwapoffSyscall, events, logger)
 	if err := z.EnsureConfigured(); err != nil {
 		logger.Sugar().Warnf("stability: zram setup failed (continuing): %v", err)

--- a/backend/cmd/stability/main.go
+++ b/backend/cmd/stability/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"context"
-	"os"
-	"os/signal"
 	"path"
 	"syscall"
 
@@ -14,9 +11,6 @@ import (
 
 func main() {
 	logger := log.Default()
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
-
 	mem := stability.NewMemInfo("/proc")
 	eventsPath := path.Join(hook.DataDir, "stability-events.jsonl")
 	stability.MigrateEventLog(path.Join(hook.CommonDir, "stability-events.jsonl"), eventsPath, logger)
@@ -31,8 +25,5 @@ func main() {
 		return syscall.Kill(pid, sig)
 	}, events, logger)
 
-	if err := watcher.Run(ctx); err != nil && err != context.Canceled {
-		logger.Sugar().Errorf("stability: watcher exited: %v", err)
-		os.Exit(1)
-	}
+	watcher.Run()
 }

--- a/backend/ioc/common.go
+++ b/backend/ioc/common.go
@@ -573,7 +573,7 @@ func Init(userConfig string, systemConfig string, backupDir string, varDir strin
 	}
 
 	err = c.Singleton(func() *stability.EventLog {
-		return stability.NewEventLog("/var/snap/platform/common/stability-events.jsonl")
+		return stability.NewEventLog("/var/snap/platform/current/stability-events.jsonl")
 	})
 	if err != nil {
 		return nil, err

--- a/backend/ioc/common.go
+++ b/backend/ioc/common.go
@@ -36,7 +36,6 @@ import (
 	"github.com/syncloud/platform/version"
 	"github.com/syncloud/platform/hardware/lcd"
 	"go.uber.org/zap"
-	"os"
 	"path"
 	"time"
 )
@@ -573,12 +572,8 @@ func Init(userConfig string, systemConfig string, backupDir string, varDir strin
 		return nil, err
 	}
 
-	err = c.Singleton(func() *stability.EventLog {
-		dataDir := os.Getenv("SNAP_DATA")
-		if dataDir == "" {
-			logger.Fatal("ioc: SNAP_DATA not set")
-		}
-		return stability.NewEventLog(dataDir + "/stability-events.jsonl")
+	err = c.Singleton(func(systemConfig *config.SystemConfig) *stability.EventLog {
+		return stability.NewEventLog(path.Join(systemConfig.DataDir(), "stability-events.jsonl"))
 	})
 	if err != nil {
 		return nil, err

--- a/backend/ioc/common.go
+++ b/backend/ioc/common.go
@@ -36,6 +36,7 @@ import (
 	"github.com/syncloud/platform/version"
 	"github.com/syncloud/platform/hardware/lcd"
 	"go.uber.org/zap"
+	"os"
 	"path"
 	"time"
 )
@@ -573,7 +574,11 @@ func Init(userConfig string, systemConfig string, backupDir string, varDir strin
 	}
 
 	err = c.Singleton(func() *stability.EventLog {
-		return stability.NewEventLog("/var/snap/platform/current/stability-events.jsonl")
+		dataDir := os.Getenv("SNAP_DATA")
+		if dataDir == "" {
+			logger.Fatal("ioc: SNAP_DATA not set")
+		}
+		return stability.NewEventLog(dataDir + "/stability-events.jsonl")
 	})
 	if err != nil {
 		return nil, err

--- a/backend/stability/migrate.go
+++ b/backend/stability/migrate.go
@@ -1,0 +1,25 @@
+package stability
+
+import (
+	"errors"
+	"os"
+
+	"go.uber.org/zap"
+)
+
+func MigrateEventLog(oldPath, newPath string, logger *zap.Logger) {
+	if _, err := os.Stat(newPath); err == nil {
+		return
+	} else if !errors.Is(err, os.ErrNotExist) {
+		logger.Warn("stability: stat new event log failed", zap.Error(err))
+		return
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		return
+	}
+	if err := os.Rename(oldPath, newPath); err != nil {
+		logger.Warn("stability: migrate event log failed", zap.String("from", oldPath), zap.String("to", newPath), zap.Error(err))
+		return
+	}
+	logger.Info("stability: migrated event log", zap.String("from", oldPath), zap.String("to", newPath))
+}

--- a/backend/stability/migrate_test.go
+++ b/backend/stability/migrate_test.go
@@ -1,0 +1,54 @@
+package stability
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestMigrateMovesWhenOnlyOldExists(t *testing.T) {
+	dir := t.TempDir()
+	old := filepath.Join(dir, "common", "events.jsonl")
+	newP := filepath.Join(dir, "data", "events.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(old), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(newP), 0755))
+	require.NoError(t, os.WriteFile(old, []byte("{\"kind\":\"x\"}\n"), 0644))
+
+	MigrateEventLog(old, newP, zap.NewNop())
+
+	_, errOld := os.Stat(old)
+	assert.True(t, os.IsNotExist(errOld))
+	body, err := os.ReadFile(newP)
+	require.NoError(t, err)
+	assert.Equal(t, "{\"kind\":\"x\"}\n", string(body))
+}
+
+func TestMigrateSkipsWhenNewAlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+	old := filepath.Join(dir, "events.jsonl")
+	newP := filepath.Join(dir, "new.jsonl")
+	require.NoError(t, os.WriteFile(old, []byte("old"), 0644))
+	require.NoError(t, os.WriteFile(newP, []byte("new"), 0644))
+
+	MigrateEventLog(old, newP, zap.NewNop())
+
+	oldBody, _ := os.ReadFile(old)
+	newBody, _ := os.ReadFile(newP)
+	assert.Equal(t, "old", string(oldBody), "old file untouched if new exists")
+	assert.Equal(t, "new", string(newBody), "new file untouched if new exists")
+}
+
+func TestMigrateNoopWhenOldMissing(t *testing.T) {
+	dir := t.TempDir()
+	old := filepath.Join(dir, "missing.jsonl")
+	newP := filepath.Join(dir, "new.jsonl")
+
+	MigrateEventLog(old, newP, zap.NewNop())
+
+	_, err := os.Stat(newP)
+	assert.True(t, os.IsNotExist(err))
+}

--- a/backend/stability/oom.go
+++ b/backend/stability/oom.go
@@ -1,7 +1,6 @@
 package stability
 
 import (
-	"context"
 	"errors"
 	"os"
 	"syscall"
@@ -42,7 +41,7 @@ func NewWatcher(mem *MemInfo, scan *ProcScanner, kill KillFn, events *EventLog, 
 	}
 }
 
-func (w *Watcher) Run(ctx context.Context) error {
+func (w *Watcher) Run() {
 	t := time.NewTicker(w.interval)
 	defer t.Stop()
 	w.log.Info("oom-watcher: started",
@@ -50,14 +49,9 @@ func (w *Watcher) Run(ctx context.Context) error {
 		zap.Float64("avail_min", w.availMin),
 		zap.Float64("psi_max", w.psiMax),
 	)
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-t.C:
-			if err := w.tick(); err != nil {
-				w.log.Warn("oom-watcher: tick error", zap.Error(err))
-			}
+	for range t.C {
+		if err := w.tick(); err != nil {
+			w.log.Warn("oom-watcher: tick error", zap.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Per CLAUDE.md convention: app state belongs in `$SNAP_DATA`, never `$SNAP_COMMON`.

- `$SNAP_DATA` is snapshotted by snapd on each refresh — copied forward on success, rolled back on failed install.
- `$SNAP_COMMON` is shared across revisions and is **not** part of that snapshotting, so on rollback an older binary can be left looking at newer-format data it doesn't understand.

The stability events log is forward-tolerant today (additive JSONL fields), but the convention is one schema change away from breaking rollbacks. Putting it in `$SNAP_DATA` is the safe place.

## Changes

- `backend/cmd/stability/main.go` — point at `$SNAP_DATA/stability-events.jsonl`.
- `backend/ioc/common.go` — backend REST reader points at the same new path.
- `backend/stability/MigrateEventLog` — one-shot move at daemon startup: if the file exists at the old `$SNAP_COMMON` path and not at the new `$SNAP_DATA` path, rename it across. Devices already on rev 2837 keep their existing history through the upgrade.

## Test plan

- [x] `go test ./stability/` — 3 new migration cases (move when only old exists, skip when new exists, no-op when neither exists).
- [ ] CI green.
- [ ] Refresh borisarm64 from this build, verify event file appears at `/var/snap/platform/current/stability-events.jsonl` and the previous `swapoff_file` event is preserved.