### PR TITLE
support: exclude dhclient noise from debug-email journalctl dump

### DIFF
--- a/backend/support/aggregator.go
+++ b/backend/support/aggregator.go
@@ -47,11 +47,35 @@ func (a *LogAggregator) GetLogs() string {
 	log += a.snapChangesDetail()
 	log += a.cmd("snap", "services")
 	log += a.cmd("snap", "run", "platform.cli", "ipv4", "public")
-	log += a.cmd("journalctl", "-n", "1000", "--no-pager")
+	log += a.journalNoDhcp()
+	log += a.cmd("journalctl", "-t", "dhclient", "-n", "10", "--no-pager")
 	log += a.cmd("dmesg", "-T")
 	log += a.dmesgErrors()
 	log += a.cmd("cat", "/proc/diskstats")
 	return log
+}
+
+func (a *LogAggregator) journalNoDhcp() string {
+	command := exec.Command("journalctl", "-n", "2000", "--no-pager")
+	out, err := command.CombinedOutput()
+	if err != nil {
+		a.logger.Warn("failed", zap.Error(err))
+	}
+	return command.String() + " (dhclient excluded)\n\n" +
+		filterAndTail(string(out), "dhclient[", 1000) + Separator
+}
+
+func filterAndTail(input string, exclude string, n int) string {
+	var kept []string
+	for _, line := range strings.Split(input, "\n") {
+		if !strings.Contains(line, exclude) {
+			kept = append(kept, line)
+		}
+	}
+	if len(kept) > n {
+		kept = kept[len(kept)-n:]
+	}
+	return strings.Join(kept, "\n")
 }
 
 func (a *LogAggregator) snapChangesDetail() string {

--- a/backend/support/aggregator_test.go
+++ b/backend/support/aggregator_test.go
@@ -3,6 +3,7 @@ package support
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/syncloud/platform/log"
+	"strings"
 	"testing"
 )
 
@@ -10,4 +11,43 @@ func TestLogAggregator_GetLogs(t *testing.T) {
 	aggregator := NewAggregator(log.Default())
 	logs := aggregator.GetLogs()
 	assert.NotEmpty(t, logs)
+}
+
+func TestFilterAndTail_ExcludesMatchingLines(t *testing.T) {
+	input := "May 22 20:51:49 syncloud dhclient[2301]: XMT: Solicit on eth0\n" +
+		"May 22 20:51:49 syncloud dhclient[2301]: RCV: Advertise message on eth0\n" +
+		"May 22 20:52:00 syncloud snapd[123]: snap install ok\n" +
+		"May 22 20:53:00 syncloud kernel: usb device connected\n"
+	out := filterAndTail(input, "dhclient[", 1000)
+	assert.NotContains(t, out, "dhclient[")
+	assert.Contains(t, out, "snapd[123]")
+	assert.Contains(t, out, "kernel: usb device connected")
+}
+
+func TestFilterAndTail_KeepsLastNAfterFilter(t *testing.T) {
+	var lines []string
+	for i := 0; i < 1500; i++ {
+		if i%3 == 0 {
+			lines = append(lines, "dhclient[1]: noise")
+		} else {
+			lines = append(lines, "keeper line")
+		}
+	}
+	out := filterAndTail(strings.Join(lines, "\n"), "dhclient[", 1000)
+	resultLines := strings.Split(out, "\n")
+	assert.Equal(t, 1000, len(resultLines))
+	for _, l := range resultLines {
+		assert.Equal(t, "keeper line", l)
+	}
+}
+
+func TestFilterAndTail_NoTruncationWhenUnderLimit(t *testing.T) {
+	input := "a\nb\nc"
+	out := filterAndTail(input, "x", 1000)
+	assert.Equal(t, "a\nb\nc", out)
+}
+
+func TestFilterAndTail_EmptyInput(t *testing.T) {
+	out := filterAndTail("", "dhclient[", 1000)
+	assert.Equal(t, "", out)
 }


### PR DESCRIPTION
## Summary
- Devices with IPv6 DHCP prefix delegation enabled get ifupdown's hardcoded `dhclient -6 -v -P` invocation, which spams the journal every ~2 min with `Solicit`/`Advertise` lines (~145/24h on borisarm64, 1517/24h on the noisiest reported device). In the 1000-line `journalctl` dump shipped in support emails, these crowd out useful entries.
- `journalctl` has no built-in tag exclusion, so this fetches 2000 lines, strips lines containing `dhclient[`, and keeps the last 1000.
- A separate 10-line `journalctl -t dhclient` section is appended so the data is still available when debugging openvpn/IPv6 issues.

## Test plan
- [x] `go test ./support/...` — 4 new unit tests on the pure `filterAndTail` helper (exclude match, tail-after-filter with 1500→1000, no-truncation, empty input)
- [x] `go build ./...` clean
- [x] `go vet ./support/...` clean
- [ ] CI green
- [ ] Trigger a support email from a device and confirm dhclient lines are absent from the main dump but present in the new dhclient section