### PR TITLE
e2e: stabilize shoot() and bump visual_diff_skip_build

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -10,7 +10,7 @@ local bootstrap = '25.02';
 local nginx = '1.24.0';
 local python = '3.12-slim-bookworm';
 local alpine = '3.21';
-local visual_diff_skip_build = '2837';
+local visual_diff_skip_build = '2846';
 
 local build(arch, testUI) = [{
   kind: 'pipeline',

--- a/web/e2e/helpers/screenshot.ts
+++ b/web/e2e/helpers/screenshot.ts
@@ -4,8 +4,23 @@ import * as fs from 'node:fs'
 
 const artifactRoot = process.env.PLAYWRIGHT_ARTIFACT_DIR ?? 'artifact'
 
+const freezeCss = '*,*::before,*::after { animation-duration: 0s !important; animation-delay: 0s !important; transition-duration: 0s !important; transition-delay: 0s !important; caret-color: transparent !important; }'
+
 function viewOf(testInfo: TestInfo): string {
   return testInfo.project.name
+}
+
+async function waitForImages(page: Page) {
+  await page.evaluate(() => Promise.all(
+    Array.from(document.images).map(img =>
+      img.complete && img.naturalWidth > 0
+        ? Promise.resolve()
+        : new Promise<void>(resolve => {
+            img.addEventListener('load', () => resolve(), { once: true })
+            img.addEventListener('error', () => resolve(), { once: true })
+          })
+    )
+  ))
 }
 
 export async function shoot(page: Page, testInfo: TestInfo, name: string) {
@@ -13,5 +28,7 @@ export async function shoot(page: Page, testInfo: TestInfo, name: string) {
   const dir = path.join(artifactRoot, 'playwright', view, 'screenshot')
   fs.mkdirSync(dir, { recursive: true })
   const file = path.join(dir, `${name}-${view}.png`)
+  await page.addStyleTag({ content: freezeCss })
+  await waitForImages(page)
   await page.screenshot({ path: file, fullPage: false })
 }


### PR DESCRIPTION
## Summary
- Visual-diff was failing intermittently because `<img>` tags load asynchronously and CSS animations could be captured mid-frame. The most blatant baseline was `activate-empty-desktop` at ~60% opacity during a fade-in.
- `shoot()` now: (a) awaits every `<img>` load/error event, (b) injects a freeze stylesheet zeroing animation/transition durations and hiding the caret, before screenshotting. No sleeps, no polling.
- Bumps `visual_diff_skip_build` 2837 → 2846 so this build skips diff vs the stale baseline. The next stable build promotes the stabilized screenshots as the new baseline; future diffs resume normally.

## Test plan
- [x] tsc clean
- [x] CI build #2850 green on all three arches
- [ ] After merge, master build green
- [ ] After master→stable, future builds diff against new stabilized baseline without flakes