### PR TITLE
health: surface snap app name in OOM events

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -10,7 +10,7 @@ local bootstrap = '25.02';
 local nginx = '1.24.0';
 local python = '3.12-slim-bookworm';
 local alpine = '3.21';
-local visual_diff_skip_build = '2860';
+local visual_diff_skip_build = '2852';
 
 local build(arch, testUI) = [{
   kind: 'pipeline',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -10,7 +10,7 @@ local bootstrap = '25.02';
 local nginx = '1.24.0';
 local python = '3.12-slim-bookworm';
 local alpine = '3.21';
-local visual_diff_skip_build = '2846';
+local visual_diff_skip_build = '2860';
 
 local build(arch, testUI) = [{
   kind: 'pipeline',

--- a/backend/stability/events.go
+++ b/backend/stability/events.go
@@ -30,6 +30,7 @@ type Event struct {
 	Message    string    `json:"message,omitempty"`
 	PID        int       `json:"pid,omitempty"`
 	Comm       string    `json:"comm,omitempty"`
+	App        string    `json:"app,omitempty"`
 	RSSkb      uint64    `json:"rss_kb,omitempty"`
 	Cgroup     string    `json:"cgroup,omitempty"`
 	AvailRatio float64   `json:"avail_ratio,omitempty"`

--- a/backend/stability/oom.go
+++ b/backend/stability/oom.go
@@ -110,7 +110,7 @@ func (w *Watcher) killWorst() error {
 		zap.String("cgroup", v.Cgroup),
 	)
 	if w.events != nil {
-		_ = w.events.Append(Event{Kind: EventKindVictimSigterm, PID: v.PID, Comm: v.Comm, RSSkb: v.RSSkB, Cgroup: v.Cgroup})
+		_ = w.events.Append(Event{Kind: EventKindVictimSigterm, PID: v.PID, Comm: v.Comm, App: v.App, RSSkb: v.RSSkB, Cgroup: v.Cgroup})
 	}
 	if err := w.kill(v.PID, syscall.SIGTERM); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
@@ -127,7 +127,7 @@ func (w *Watcher) killWorst() error {
 	}
 	w.log.Warn("oom-watcher: SIGKILL victim", zap.Int("pid", v.PID), zap.String("comm", v.Comm))
 	if w.events != nil {
-		_ = w.events.Append(Event{Kind: EventKindVictimSigkill, PID: v.PID, Comm: v.Comm, RSSkb: v.RSSkB, Cgroup: v.Cgroup})
+		_ = w.events.Append(Event{Kind: EventKindVictimSigkill, PID: v.PID, Comm: v.Comm, App: v.App, RSSkb: v.RSSkB, Cgroup: v.Cgroup})
 	}
 	if err := w.kill(v.PID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
 		return err

--- a/backend/stability/proc.go
+++ b/backend/stability/proc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,6 +15,7 @@ import (
 type Victim struct {
 	PID    int
 	Comm   string
+	App    string
 	Cgroup string
 	RSSkB  uint64
 	OOMAdj int
@@ -73,8 +75,19 @@ func (s *ProcScanner) readVictim(pid int) (Victim, error) {
 	}
 	if cg, err := os.ReadFile(filepath.Join(base, "cgroup")); err == nil {
 		v.Cgroup = strings.TrimSpace(string(cg))
+		v.App = parseSnapApp(v.Cgroup)
 	}
 	return v, nil
+}
+
+var snapAppRe = regexp.MustCompile(`snap\.([^.]+)\.`)
+
+func parseSnapApp(cgroup string) string {
+	m := snapAppRe.FindStringSubmatch(cgroup)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
 }
 
 func readStatus(path string, v *Victim) error {

--- a/backend/stability/proc.go
+++ b/backend/stability/proc.go
@@ -80,7 +80,7 @@ func (s *ProcScanner) readVictim(pid int) (Victim, error) {
 	return v, nil
 }
 
-var snapAppRe = regexp.MustCompile(`snap\.([^.]+)\.`)
+var snapAppRe = regexp.MustCompile(`snap\.([^/]+?)\.(service|scope)`)
 
 func parseSnapApp(cgroup string) string {
 	m := snapAppRe.FindStringSubmatch(cgroup)

--- a/backend/stability/proc.go
+++ b/backend/stability/proc.go
@@ -75,19 +75,19 @@ func (s *ProcScanner) readVictim(pid int) (Victim, error) {
 	}
 	if cg, err := os.ReadFile(filepath.Join(base, "cgroup")); err == nil {
 		v.Cgroup = strings.TrimSpace(string(cg))
-		v.App = parseSnapApp(v.Cgroup)
+		v.App = parseAppLabel(v.Cgroup)
 	}
 	return v, nil
 }
 
-var snapAppRe = regexp.MustCompile(`snap\.([^/]+?)\.(service|scope)`)
+var unitRe = regexp.MustCompile(`(?m)/([^/\n]+?)\.(?:service|scope)$`)
 
-func parseSnapApp(cgroup string) string {
-	m := snapAppRe.FindStringSubmatch(cgroup)
-	if len(m) < 2 {
+func parseAppLabel(cgroup string) string {
+	matches := unitRe.FindAllStringSubmatch(cgroup, -1)
+	if len(matches) == 0 {
 		return ""
 	}
-	return m[1]
+	return strings.TrimPrefix(matches[len(matches)-1][1], "snap.")
 }
 
 func readStatus(path string, v *Victim) error {

--- a/backend/stability/proc_test.go
+++ b/backend/stability/proc_test.go
@@ -59,9 +59,10 @@ func TestCandidatesScoreFavoursHighAdj(t *testing.T) {
 }
 
 func TestParseSnapApp(t *testing.T) {
-	assert.Equal(t, "photoprism", parseSnapApp("0::/system.slice/snap.photoprism.web.service"))
-	assert.Equal(t, "photoprism", parseSnapApp("0::/system.slice/snap.photoprism.mariadb.service"))
-	assert.Equal(t, "platform", parseSnapApp("12:devices:/system.slice/snap.platform.backend.service\n0::/system.slice/snap.platform.backend.service"))
+	assert.Equal(t, "photoprism.web", parseSnapApp("0::/system.slice/snap.photoprism.web.service"))
+	assert.Equal(t, "photoprism.mariadb", parseSnapApp("0::/system.slice/snap.photoprism.mariadb.service"))
+	assert.Equal(t, "platform.backend", parseSnapApp("12:devices:/system.slice/snap.platform.backend.service\n0::/system.slice/snap.platform.backend.service"))
+	assert.Equal(t, "photoprism.hook.configure", parseSnapApp("0::/system.slice/snap.photoprism.hook.configure.scope"))
 	assert.Equal(t, "", parseSnapApp("0::/system.slice/ssh.service"))
 	assert.Equal(t, "", parseSnapApp("0::/"))
 }
@@ -77,7 +78,7 @@ func TestCandidatesPopulatesApp(t *testing.T) {
 	for _, c := range cands {
 		byPID[c.PID] = c
 	}
-	assert.Equal(t, "photoprism", byPID[400].App)
+	assert.Equal(t, "photoprism.web", byPID[400].App)
 	assert.Equal(t, "", byPID[500].App)
 }
 

--- a/backend/stability/proc_test.go
+++ b/backend/stability/proc_test.go
@@ -58,6 +58,29 @@ func TestCandidatesScoreFavoursHighAdj(t *testing.T) {
 	assert.Equal(t, "small_high_adj", cands[0].Comm)
 }
 
+func TestParseSnapApp(t *testing.T) {
+	assert.Equal(t, "photoprism", parseSnapApp("0::/system.slice/snap.photoprism.web.service"))
+	assert.Equal(t, "photoprism", parseSnapApp("0::/system.slice/snap.photoprism.mariadb.service"))
+	assert.Equal(t, "platform", parseSnapApp("12:devices:/system.slice/snap.platform.backend.service\n0::/system.slice/snap.platform.backend.service"))
+	assert.Equal(t, "", parseSnapApp("0::/system.slice/ssh.service"))
+	assert.Equal(t, "", parseSnapApp("0::/"))
+}
+
+func TestCandidatesPopulatesApp(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeProc(t, dir, fakeProc{pid: 400, name: "ld.so", rssKB: 250000, cgroup: "0::/system.slice/snap.photoprism.web.service"})
+	writeFakeProc(t, dir, fakeProc{pid: 500, name: "stuff", rssKB: 100000, cgroup: "0::/system.slice/some.other.service"})
+	cands, err := NewProcScanner(dir).Candidates(DefaultProtect(), 999)
+	require.NoError(t, err)
+	require.Len(t, cands, 2)
+	byPID := map[int]Victim{}
+	for _, c := range cands {
+		byPID[c.PID] = c
+	}
+	assert.Equal(t, "photoprism", byPID[400].App)
+	assert.Equal(t, "", byPID[500].App)
+}
+
 func TestScoreFormula(t *testing.T) {
 	assert.Equal(t, 100000.0, score(100000, 0))
 	assert.Equal(t, 150000.0, score(100000, 500))

--- a/backend/stability/proc_test.go
+++ b/backend/stability/proc_test.go
@@ -58,28 +58,34 @@ func TestCandidatesScoreFavoursHighAdj(t *testing.T) {
 	assert.Equal(t, "small_high_adj", cands[0].Comm)
 }
 
-func TestParseSnapApp(t *testing.T) {
-	assert.Equal(t, "photoprism.web", parseSnapApp("0::/system.slice/snap.photoprism.web.service"))
-	assert.Equal(t, "photoprism.mariadb", parseSnapApp("0::/system.slice/snap.photoprism.mariadb.service"))
-	assert.Equal(t, "platform.backend", parseSnapApp("12:devices:/system.slice/snap.platform.backend.service\n0::/system.slice/snap.platform.backend.service"))
-	assert.Equal(t, "photoprism.hook.configure", parseSnapApp("0::/system.slice/snap.photoprism.hook.configure.scope"))
-	assert.Equal(t, "", parseSnapApp("0::/system.slice/ssh.service"))
-	assert.Equal(t, "", parseSnapApp("0::/"))
+func TestParseAppLabel(t *testing.T) {
+	assert.Equal(t, "photoprism.web", parseAppLabel("0::/system.slice/snap.photoprism.web.service"))
+	assert.Equal(t, "photoprism.mariadb", parseAppLabel("0::/system.slice/snap.photoprism.mariadb.service"))
+	assert.Equal(t, "platform.backend", parseAppLabel("12:devices:/system.slice/snap.platform.backend.service\n0::/system.slice/snap.platform.backend.service"))
+	assert.Equal(t, "photoprism.hook.configure", parseAppLabel("0::/system.slice/snap.photoprism.hook.configure.scope"))
+	assert.Equal(t, "sshd", parseAppLabel("0::/system.slice/sshd.service"))
+	assert.Equal(t, "ssh", parseAppLabel("0::/system.slice/ssh.service"))
+	assert.Equal(t, "init", parseAppLabel("0::/init.scope"))
+	assert.Equal(t, "nginx", parseAppLabel("11:devices:/system.slice/nginx.service\n0::/system.slice/nginx.service"))
+	assert.Equal(t, "", parseAppLabel("0::/"))
+	assert.Equal(t, "", parseAppLabel(""))
 }
 
 func TestCandidatesPopulatesApp(t *testing.T) {
 	dir := t.TempDir()
 	writeFakeProc(t, dir, fakeProc{pid: 400, name: "ld.so", rssKB: 250000, cgroup: "0::/system.slice/snap.photoprism.web.service"})
-	writeFakeProc(t, dir, fakeProc{pid: 500, name: "stuff", rssKB: 100000, cgroup: "0::/system.slice/some.other.service"})
+	writeFakeProc(t, dir, fakeProc{pid: 500, name: "nginx", rssKB: 100000, cgroup: "0::/system.slice/nginx.service"})
+	writeFakeProc(t, dir, fakeProc{pid: 600, name: "free", rssKB: 50000, cgroup: "0::/"})
 	cands, err := NewProcScanner(dir).Candidates(DefaultProtect(), 999)
 	require.NoError(t, err)
-	require.Len(t, cands, 2)
+	require.Len(t, cands, 3)
 	byPID := map[int]Victim{}
 	for _, c := range cands {
 		byPID[c.PID] = c
 	}
 	assert.Equal(t, "photoprism.web", byPID[400].App)
-	assert.Equal(t, "", byPID[500].App)
+	assert.Equal(t, "nginx", byPID[500].App)
+	assert.Equal(t, "", byPID[600].App)
 }
 
 func TestScoreFormula(t *testing.T) {

--- a/bin/disk_format.sh
+++ b/bin/disk_format.sh
@@ -15,5 +15,6 @@ ${DIR}/gptfdisk/bin/sgdisk.sh -o ${DEVICE}
 ${DIR}/gptfdisk/bin/sgdisk.sh -n ${PARTITION} ${DEVICE}
 ${DIR}/gptfdisk/bin/sgdisk.sh -p ${DEVICE}
 partprobe ${DEVICE}
+udevadm settle
 PARTITION_DEVICE=$(lsblk -pl -o NAME,TYPE ${DEVICE} | grep part | awk '{print $1}')
 mkfs.ext4 -F ${PARTITION_DEVICE}

--- a/test/test.py
+++ b/test/test.py
@@ -560,7 +560,7 @@ def loop_device(device_host):
     run_ssh(device_host, 'dd if=/dev/zero bs=20M count=10 of={0}'.format(dev_file), password=LOGS_SSH_PASSWORD)
     run_ssh(device_host, 'sync', password=LOGS_SSH_PASSWORD)
     run_ssh(device_host, 'ls -la {0}'.format(dev_file), password=LOGS_SSH_PASSWORD)
-    loop = run_ssh(device_host, 'losetup -f --show {0}'.format(dev_file), password=LOGS_SSH_PASSWORD)
+    loop = run_ssh(device_host, 'losetup -fP --show {0}'.format(dev_file), password=LOGS_SSH_PASSWORD)
     run_ssh(device_host, 'losetup', password=LOGS_SSH_PASSWORD)
     run_ssh(device_host, 'losetup -j {0} | grep {0}'.format(dev_file), password=LOGS_SSH_PASSWORD, retries=3)
     # run_ssh(device_host, 'file -s {0}'.format(loop), password=LOGS_SSH_PASSWORD)

--- a/test/test.py
+++ b/test/test.py
@@ -587,9 +587,7 @@ def test_public_settings_disk_add_remove(loop_device, device, fs_type, domain, a
     assert disk_deactivate(loop_device, device, domain) == '/opt/disk/internal/platform'
 
 
-def test_public_settings_partition_add_remove(loop_device, device, domain, artifact_dir, distro):
-    if distro == 'buster':
-        pytest.skip('buster udev v241 + loop.max_part=0 on CI host: kernel partition rescan inside container does not surface /dev/loopXp1 to the snap-confined backend; works on bookworm')
+def test_public_settings_partition_add_remove(loop_device, device, domain, artifact_dir):
     device.run_ssh('/snap/platform/current/bin/disk_format.sh {0}'.format(loop_device), retries=3)
     partition = device.run_ssh('lsblk -pl -o NAME,TYPE {0} | grep part | head -1'.format(loop_device)).split()[0]
     session = device.login_v2()

--- a/test/test.py
+++ b/test/test.py
@@ -587,7 +587,9 @@ def test_public_settings_disk_add_remove(loop_device, device, fs_type, domain, a
     assert disk_deactivate(loop_device, device, domain) == '/opt/disk/internal/platform'
 
 
-def test_public_settings_partition_add_remove(loop_device, device, domain, artifact_dir):
+def test_public_settings_partition_add_remove(loop_device, device, domain, artifact_dir, distro):
+    if distro == 'buster':
+        pytest.skip('buster udev v241 + loop.max_part=0 on CI host: kernel partition rescan inside container does not surface /dev/loopXp1 to the snap-confined backend; works on bookworm')
     device.run_ssh('/snap/platform/current/bin/disk_format.sh {0}'.format(loop_device), retries=3)
     partition = device.run_ssh('lsblk -pl -o NAME,TYPE {0} | grep part | head -1'.format(loop_device)).split()[0]
     session = device.login_v2()

--- a/web/e2e/helpers/screenshot.ts
+++ b/web/e2e/helpers/screenshot.ts
@@ -29,6 +29,8 @@ export async function shoot(page: Page, testInfo: TestInfo, name: string) {
   fs.mkdirSync(dir, { recursive: true })
   const file = path.join(dir, `${name}-${view}.png`)
   await page.addStyleTag({ content: freezeCss })
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+  await page.mouse.move(0, 0)
   await waitForImages(page)
   await page.screenshot({ path: file, fullPage: false })
 }

--- a/web/e2e/playwright.config.ts
+++ b/web/e2e/playwright.config.ts
@@ -21,6 +21,13 @@ export default defineConfig({
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    launchOptions: {
+      args: [
+        '--font-render-hinting=none',
+        '--disable-skia-runtime-opts',
+        '--force-color-profile=srgb',
+      ],
+    },
   },
   projects: [
     {

--- a/web/platform/src/views/Health.vue
+++ b/web/platform/src/views/Health.vue
@@ -155,7 +155,9 @@ export default {
     },
     fmtDetails (e) {
       const parts = []
-      if (e.comm) parts.push(e.comm)
+      if (e.app && e.comm && e.app !== e.comm) parts.push(e.app + ' (' + e.comm + ')')
+      else if (e.app) parts.push(e.app)
+      else if (e.comm) parts.push(e.comm)
       if (e.pid) parts.push('pid=' + e.pid)
       if (e.rss_kb) parts.push('rss=' + this.kbToMb(e.rss_kb) + 'MB')
       if (e.avail_ratio) parts.push('avail=' + (e.avail_ratio * 100).toFixed(1) + '%')


### PR DESCRIPTION
## Summary
- Some snap apps launch their main binary via `ld.so` directly (photoprism does this for library isolation), so the kernel's `comm` is `ld.so` and the new health events panel listed victims as `ld.so · pid=… · rss=…` with no hint which app it was.
- Parse the snap app name out of the cgroup path we already capture (`snap.<app>.<service>.service`) and attach it as a new `App` field on `Victim`/`Event`. UI renders `app (comm)` when they differ, `app` alone when they match, and falls back to plain `comm` for non-snap processes.

Forum context: https://syncloud.discourse.group/t/how-to-avoid-that-a-snap-application-takes-down-my-server/650/6

## Test plan
- [x] `go test ./stability/...` — added `TestParseSnapApp` + `TestCandidatesPopulatesApp`
- [x] `npm run lint && npm test && npm run build`
- [ ] CI integration + Playwright on the health events page