### PR TITLE
support: split debug-email journal into signal + noise tail

### DIFF
--- a/backend/support/aggregator.go
+++ b/backend/support/aggregator.go
@@ -56,20 +56,22 @@ func (a *LogAggregator) GetLogs() string {
 	return log
 }
 
+var dhcpNoise = regexp.MustCompile(`dhclient\[|]: (XMT|RCV|PRC):`)
+
 func (a *LogAggregator) journalNoDhcp() string {
-	command := exec.Command("journalctl", "-n", "2000", "--no-pager")
+	command := exec.Command("journalctl", "-n", "5000", "--no-pager")
 	out, err := command.CombinedOutput()
 	if err != nil {
 		a.logger.Warn("failed", zap.Error(err))
 	}
-	return command.String() + " (dhclient excluded)\n\n" +
-		filterAndTail(string(out), "dhclient[", 1000) + Separator
+	return command.String() + " (dhcp noise excluded)\n\n" +
+		filterAndTail(string(out), dhcpNoise, 1000) + Separator
 }
 
-func filterAndTail(input string, exclude string, n int) string {
+func filterAndTail(input string, exclude *regexp.Regexp, n int) string {
 	var kept []string
 	for _, line := range strings.Split(input, "\n") {
-		if !strings.Contains(line, exclude) {
+		if !exclude.MatchString(line) {
 			kept = append(kept, line)
 		}
 	}

--- a/backend/support/aggregator.go
+++ b/backend/support/aggregator.go
@@ -47,38 +47,37 @@ func (a *LogAggregator) GetLogs() string {
 	log += a.snapChangesDetail()
 	log += a.cmd("snap", "services")
 	log += a.cmd("snap", "run", "platform.cli", "ipv4", "public")
-	log += a.journalNoDhcp()
+	log += a.journal()
 	log += a.previousBootTail()
-	log += a.cmd("journalctl", "-t", "dhclient", "-n", "10", "--no-pager")
 	log += a.cmd("dmesg", "-T")
 	log += a.dmesgErrors()
 	log += a.cmd("cat", "/proc/diskstats")
 	return log
 }
 
-var dhcpNoise = regexp.MustCompile(`dhclient\[|]: (XMT|RCV|PRC):`)
+var noise = regexp.MustCompile(`dhclient\[|]: (XMT|RCV|PRC):`)
 
-func (a *LogAggregator) journalNoDhcp() string {
+func (a *LogAggregator) journal() string {
 	command := exec.Command("journalctl", "-n", "5000", "--no-pager")
 	out, err := command.CombinedOutput()
 	if err != nil {
 		a.logger.Warn("failed", zap.Error(err))
 	}
-	return command.String() + " (dhcp noise excluded)\n\n" +
-		filterAndTail(string(out), dhcpNoise, 1000) + Separator
+	signal, noisy := splitNoise(string(out))
+	return command.String() + "\n\n" + tail(signal, 1000) + Separator +
+		"journal noise tail (filtered out above)\n\n" + tail(noisy, 100) + Separator
 }
 
-func filterAndTail(input string, exclude *regexp.Regexp, n int) string {
-	var kept []string
+func splitNoise(input string) (string, string) {
+	var signal, noisy []string
 	for _, line := range strings.Split(input, "\n") {
-		if !exclude.MatchString(line) {
-			kept = append(kept, line)
+		if noise.MatchString(line) {
+			noisy = append(noisy, line)
+		} else {
+			signal = append(signal, line)
 		}
 	}
-	if len(kept) > n {
-		kept = kept[len(kept)-n:]
-	}
-	return strings.Join(kept, "\n")
+	return strings.Join(signal, "\n"), strings.Join(noisy, "\n")
 }
 
 func (a *LogAggregator) previousBootTail() string {

--- a/backend/support/aggregator_test.go
+++ b/backend/support/aggregator_test.go
@@ -3,6 +3,7 @@ package support
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/syncloud/platform/log"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -13,13 +14,18 @@ func TestLogAggregator_GetLogs(t *testing.T) {
 	assert.NotEmpty(t, logs)
 }
 
-func TestFilterAndTail_ExcludesMatchingLines(t *testing.T) {
+func TestFilterAndTail_ExcludesDhcpRegardlessOfTag(t *testing.T) {
 	input := "May 22 20:51:49 syncloud dhclient[2301]: XMT: Solicit on eth0\n" +
-		"May 22 20:51:49 syncloud dhclient[2301]: RCV: Advertise message on eth0\n" +
+		"May 22 20:51:49 syncloud sh[2611]: RCV: Advertise message on eth0\n" +
+		"May 22 20:51:49 syncloud sh[2611]: RCV:  | X-- t2 - rebind +0\n" +
+		"May 22 20:51:49 syncloud sh[2611]: PRC: Lease failed to satisfy.\n" +
 		"May 22 20:52:00 syncloud snapd[123]: snap install ok\n" +
 		"May 22 20:53:00 syncloud kernel: usb device connected\n"
-	out := filterAndTail(input, "dhclient[", 1000)
+	out := filterAndTail(input, dhcpNoise, 1000)
 	assert.NotContains(t, out, "dhclient[")
+	assert.NotContains(t, out, "Advertise")
+	assert.NotContains(t, out, "rebind")
+	assert.NotContains(t, out, "Lease failed")
 	assert.Contains(t, out, "snapd[123]")
 	assert.Contains(t, out, "kernel: usb device connected")
 }
@@ -33,7 +39,7 @@ func TestFilterAndTail_KeepsLastNAfterFilter(t *testing.T) {
 			lines = append(lines, "keeper line")
 		}
 	}
-	out := filterAndTail(strings.Join(lines, "\n"), "dhclient[", 1000)
+	out := filterAndTail(strings.Join(lines, "\n"), dhcpNoise, 1000)
 	resultLines := strings.Split(out, "\n")
 	assert.Equal(t, 1000, len(resultLines))
 	for _, l := range resultLines {
@@ -43,11 +49,11 @@ func TestFilterAndTail_KeepsLastNAfterFilter(t *testing.T) {
 
 func TestFilterAndTail_NoTruncationWhenUnderLimit(t *testing.T) {
 	input := "a\nb\nc"
-	out := filterAndTail(input, "x", 1000)
+	out := filterAndTail(input, regexp.MustCompile("x"), 1000)
 	assert.Equal(t, "a\nb\nc", out)
 }
 
 func TestFilterAndTail_EmptyInput(t *testing.T) {
-	out := filterAndTail("", "dhclient[", 1000)
+	out := filterAndTail("", dhcpNoise, 1000)
 	assert.Equal(t, "", out)
 }

--- a/backend/support/aggregator_test.go
+++ b/backend/support/aggregator_test.go
@@ -1,9 +1,9 @@
 package support
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/syncloud/platform/log"
-	"regexp"
 	"strings"
 	"testing"
 )
@@ -14,46 +14,43 @@ func TestLogAggregator_GetLogs(t *testing.T) {
 	assert.NotEmpty(t, logs)
 }
 
-func TestFilterAndTail_ExcludesDhcpRegardlessOfTag(t *testing.T) {
+func TestSplitNoise_SeparatesDhcpRegardlessOfTag(t *testing.T) {
 	input := "May 22 20:51:49 syncloud dhclient[2301]: XMT: Solicit on eth0\n" +
 		"May 22 20:51:49 syncloud sh[2611]: RCV: Advertise message on eth0\n" +
 		"May 22 20:51:49 syncloud sh[2611]: RCV:  | X-- t2 - rebind +0\n" +
 		"May 22 20:51:49 syncloud sh[2611]: PRC: Lease failed to satisfy.\n" +
 		"May 22 20:52:00 syncloud snapd[123]: snap install ok\n" +
 		"May 22 20:53:00 syncloud kernel: usb device connected\n"
-	out := filterAndTail(input, dhcpNoise, 1000)
-	assert.NotContains(t, out, "dhclient[")
-	assert.NotContains(t, out, "Advertise")
-	assert.NotContains(t, out, "rebind")
-	assert.NotContains(t, out, "Lease failed")
-	assert.Contains(t, out, "snapd[123]")
-	assert.Contains(t, out, "kernel: usb device connected")
+	signal, noisy := splitNoise(input)
+	assert.NotContains(t, signal, "dhclient[")
+	assert.NotContains(t, signal, "Advertise")
+	assert.NotContains(t, signal, "rebind")
+	assert.NotContains(t, signal, "Lease failed")
+	assert.Contains(t, signal, "snapd[123]")
+	assert.Contains(t, signal, "kernel: usb device connected")
+	assert.Contains(t, noisy, "Lease failed")
+	assert.Contains(t, noisy, "Advertise")
+	assert.Contains(t, noisy, "rebind")
+	assert.NotContains(t, noisy, "snapd[123]")
 }
 
-func TestFilterAndTail_KeepsLastNAfterFilter(t *testing.T) {
+func TestSplitNoise_EmptyInput(t *testing.T) {
+	signal, noisy := splitNoise("")
+	assert.Equal(t, "", signal)
+	assert.Equal(t, "", noisy)
+}
+
+func TestTail_KeepsLastN(t *testing.T) {
 	var lines []string
 	for i := 0; i < 1500; i++ {
-		if i%3 == 0 {
-			lines = append(lines, "dhclient[1]: noise")
-		} else {
-			lines = append(lines, "keeper line")
-		}
+		lines = append(lines, fmt.Sprintf("line %d", i))
 	}
-	out := filterAndTail(strings.Join(lines, "\n"), dhcpNoise, 1000)
-	resultLines := strings.Split(out, "\n")
-	assert.Equal(t, 1000, len(resultLines))
-	for _, l := range resultLines {
-		assert.Equal(t, "keeper line", l)
-	}
+	result := strings.Split(tail(strings.Join(lines, "\n"), 1000), "\n")
+	assert.Equal(t, 1000, len(result))
+	assert.Equal(t, "line 500", result[0])
+	assert.Equal(t, "line 1499", result[999])
 }
 
-func TestFilterAndTail_NoTruncationWhenUnderLimit(t *testing.T) {
-	input := "a\nb\nc"
-	out := filterAndTail(input, regexp.MustCompile("x"), 1000)
-	assert.Equal(t, "a\nb\nc", out)
-}
-
-func TestFilterAndTail_EmptyInput(t *testing.T) {
-	out := filterAndTail("", dhcpNoise, 1000)
-	assert.Equal(t, "", out)
+func TestTail_NoTruncationWhenUnderLimit(t *testing.T) {
+	assert.Equal(t, "a\nb\nc", tail("a\nb\nc", 1000))
 }


### PR DESCRIPTION
## Problem

The debug-email `journalctl` dump tried to exclude DHCP noise but only filtered the literal `dhclient[` syslog tag. The DHCPv6 prefix-delegation client runs under a shell wrapper (`ifup` → `sh -c "dhclient -6 -v -P …"`), so journald tags its output **`sh[<pid>]`** — and the old filter dropped **0** lines on a real device while that spam was **304 of 998 (~30%)** of the section.

## Change

Two commits:

1. **Match the noise by message token, not syslog tag** — `dhclient[` or `]: (XMT|RCV|PRC):` — so it's caught whether journald labels the writer `sh` or `dhclient`. Widen the fetch `2000 → 5000`.
2. **Split instead of drop.** Rename the dhcp-specific filter to a generic `noise` mask and partition the journal in one pass:
   - **signal** section — `tail 1000` of the non-noise lines (reaches much further back now that the flood is gone)
   - **journal noise tail** section — `tail 100` of the suppressed lines, so noise is *sampled, not silently lost*
   - removes `filterAndTail` and the now-redundant `journalctl -t dhclient -n 10` section; reuses the existing `tail()`.

Rationale: the mask is noise we can't control at the device, but blanket-dropping risks hiding a real event inside what we classify as noise. A 100-line tail keeps a safety sample — e.g. the `Status code of no prefix, IA_PD discarded` / `Lease failed to satisfy` evidence still survives.

## Validation against the real report

```
total journal lines : 1026
signal section      : 722 lines (tail 1000 => all kept)
noise  section      : 304 lines (tail 100 shown 'just in case')
non-noise wrongly classified as noise: 0
```

`go vet`, `go build ./...`, `go test ./support/` all pass.

## Follow-ups (not in this PR)

Source-side reductions found while debugging (log less rather than filter):
- **authelia** at `trace` → `warn` + fix deprecated `webauthn.user_verification` / oidc `grant_types` keys (173 lines)
- **ntpd** DNS-pool chatter (141), **backend** retryablehttp DEBUG (120), **slapd** `olcLogLevel` (99)
- **Drop `request_prefix 1`** from the image's `/etc/network/interfaces`: DHCPv6-PD has failed continuously since **March 2024** (Starlink returns 'no prefix available'); the box's own IPv6 via SLAAC is unaffected, so the failing `-P` client is pure noise.
- Add `ip -6 addr` / `ip -6 route` to the email so IPv6 state is visible positively instead of via failure spam.