### PR TITLE
App Center: show app descriptions for not-installed apps

### DIFF
--- a/backend/snap/model/store_catalog.go
+++ b/backend/snap/model/store_catalog.go
@@ -1,0 +1,10 @@
+package model
+
+type StoreCatalog struct {
+	Apps []StoreCatalogApp `json:"apps"`
+}
+
+type StoreCatalogApp struct {
+	Id          string `json:"id"`
+	Description string `json:"description"`
+}

--- a/backend/snap/server.go
+++ b/backend/snap/server.go
@@ -85,14 +85,45 @@ func (s *Server) StoreUserApps() ([]model.SyncloudApp, error) {
 	if err != nil {
 		return nil, err
 	}
+	descriptions := s.storeDescriptions()
 	var apps []model.SyncloudApp
 	for _, snap := range snaps {
 		if snap.IsApp() {
 			app := snap.ToStoreApp(s.userConfig.Url(snap.Name))
+			if app.App.Description == "" {
+				app.App.Description = descriptions[snap.Name]
+			}
 			apps = append(apps, app.App)
 		}
 	}
 	return apps, nil
+}
+
+func (s *Server) storeDescriptions() map[string]string {
+	descriptions := map[string]string{}
+	channel := s.systemConfig.Channel()
+	resp, err := s.httpClient.Get(fmt.Sprintf("http://apps.syncloud.org/releases/%s/index-v2", channel))
+	if err != nil {
+		s.logger.Warn("cannot fetch store catalog", zap.Error(err))
+		return descriptions
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		s.logger.Warn("cannot read store catalog", zap.Error(err))
+		return descriptions
+	}
+	var catalog model.StoreCatalog
+	if err := json.Unmarshal(body, &catalog); err != nil {
+		s.logger.Warn("cannot parse store catalog", zap.Error(err))
+		return descriptions
+	}
+	for _, app := range catalog.Apps {
+		if app.Description != "" {
+			descriptions[app.Id] = app.Description
+		}
+	}
+	return descriptions
 }
 
 func (s *Server) Snaps() ([]model.Snap, error) {
@@ -281,8 +312,11 @@ func (s *Server) FindInStore(name string) (*model.SyncloudAppVersions, error) {
 		s.logger.Warn("More than one app found")
 	}
 	snap := found[0]
-	installedApp := snap.ToStoreApp(s.userConfig.Url(snap.Name))
-	return &installedApp, nil
+	storeApp := snap.ToStoreApp(s.userConfig.Url(snap.Name))
+	if storeApp.App.Description == "" {
+		storeApp.App.Description = s.storeDescriptions()[snap.Name]
+	}
+	return &storeApp, nil
 }
 
 func (s *Server) Find(name string) (*model.SyncloudAppVersions, error) {

--- a/backend/snap/server_test.go
+++ b/backend/snap/server_test.go
@@ -302,6 +302,32 @@ func TestStoreUserApps_OK(t *testing.T) {
 	assert.Equal(t, apps[0].Id, "app")
 }
 
+func TestStoreUserApps_DescriptionFromCatalog(t *testing.T) {
+	findJson := `
+{
+	"result": [
+		{
+			"name": "app",
+			"summary": "app summary",
+			"description": "",
+			"channel": "stable",
+			"version": "1",
+			"type": "app",
+			"apps": [ { "name": "app", "snap": "app" } ]
+		}
+	]
+}
+`
+	catalog := `{ "apps": [ { "id": "app", "description": "catalog description" } ] }`
+
+	snapd := NewServer(&ClientStub{findJson: findJson}, &SystemConfigStub{}, &UserConfigStub{}, &HttpClientStub{response: catalog, status: 200}, log.Default())
+	apps, err := snapd.StoreUserApps()
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(apps))
+	assert.Equal(t, "catalog description", apps[0].Description)
+}
+
 func TestServer_FindInStore_Found(t *testing.T) {
 	json := `
 { 

--- a/web/e2e/specs/06-app-center.spec.ts
+++ b/web/e2e/specs/06-app-center.spec.ts
@@ -66,6 +66,7 @@ test('not installed app', async ({}, testInfo) => {
   await page.getByText('File browser').click()
   await expect(page.getByRole('heading', { name: 'File browser' })).toBeVisible()
   await expect(page.locator('#btn_install')).toBeVisible()
+  await expect(page.getByTestId('app_description')).toHaveText('Simple device files browser')
   await shoot(page, testInfo, 'app_not_installed')
 })
 

--- a/web/platform/src/views/App.vue
+++ b/web/platform/src/views/App.vue
@@ -61,7 +61,7 @@
         <span v-if="info.local_install" id="local_install_badge" data-testid="local_install_badge" class="app-badge">{{ $t('app.localInstall') }}</span>
       </div>
 
-      <p class="app-description" v-if="showDescription">{{ info.app.description }}</p>
+      <p class="app-description" data-testid="app_description" v-if="showDescription">{{ info.app.description }}</p>
     </div>
   </div>
 


### PR DESCRIPTION
## Problem

The platform UI redesign (#747) added an app description block to the app page. It shows for **installed** apps but is blank for apps opened from the **App Center** (not yet installed).

## Root cause

- Installed app page → `Find()` uses snapd `/v2/snaps` (local snap metadata), which carries `description` → shown.
- Store / not-installed app page → `Find()` returns `FindInStore()` from snapd `/v2/find`, which returned `description: ""` → `showDescription` hides it.

The empty description originates in the store, which dropped the `snap.yaml` description from its find/info responses. Fixed there in syncloud/store#6; once that store change is deployed, snapd relays the description and the platform's existing `Description: s.Description` mapping shows it — no platform code change needed.

## Contents

- Playwright assertion on the not-installed File browser page that the description renders, plus a `data-testid` on the description element.

This test stays red until syncloud/store#6 is merged and deployed to the store.