### PR TITLE
login web: fix mobile keyboard layout + add dev:stub

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -10,7 +10,7 @@ local bootstrap = '25.02';
 local nginx = '1.24.0';
 local python = '3.12-slim-bookworm';
 local alpine = '3.21';
-local visual_diff_skip_build = '2960';
+local visual_diff_skip_build = '2987';
 
 local build(arch, testUI) = [{
   kind: 'pipeline',

--- a/web/login/index.html
+++ b/web/login/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, interactive-widget=resizes-content">
     <link rel="icon" href="/favicon.ico">
     <title>Sign in - Syncloud</title>
   </head>

--- a/web/login/package-lock.json
+++ b/web/login/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^1.6.1",
+        "miragejs": "^0.1.48",
         "vite": "^2.5.4"
       }
     },
@@ -84,6 +85,13 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@miragejs/pretender-node-polyfill": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz",
+      "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -802,6 +810,13 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/fake-xml-http-request": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz",
+      "integrity": "sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -972,6 +987,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/inflected": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.1.0.tgz",
+      "integrity": "sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -1009,6 +1031,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1037,6 +1066,22 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/miragejs": {
+      "version": "0.1.48",
+      "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.48.tgz",
+      "integrity": "sha512-MGZAq0Q3OuRYgZKvlB69z4gLN4G3PvgC4A2zhkCXCXrLD5wm2cCnwNB59xOBVA+srZ0zEes6u+VylcPIkB4SqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@miragejs/pretender-node-polyfill": "^0.1.0",
+        "inflected": "^2.0.4",
+        "lodash": "^4.0.0",
+        "pretender": "^3.4.7"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/nanoid": {
@@ -1152,6 +1197,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretender": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.4.7.tgz",
+      "integrity": "sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fake-xml-http-request": "^2.1.2",
+        "route-recognizer": "^0.3.3"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -1226,6 +1282,13 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/route-recognizer": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
+      "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",

--- a/web/login/package.json
+++ b/web/login/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "dev:stub": "VITE_STUB=1 vite",
     "build": "vite build",
     "lint": "eslint --fix src"
   },
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^1.6.1",
+    "miragejs": "^0.1.48",
     "vite": "^2.5.4"
   }
 }

--- a/web/login/src/LoginApp.vue
+++ b/web/login/src/LoginApp.vue
@@ -324,13 +324,14 @@ body {
   color: var(--lg-ink);
   background: linear-gradient(140deg, #f7fafe 0%, #eaf2fb 55%, #dbe7f4 100%);
   min-height: 100vh;
+  min-height: 100dvh;
 }
 .login-root {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   padding: 40px 16px;
 }
 .login-wordmark {
@@ -338,11 +339,13 @@ body {
   font-weight: 700;
   letter-spacing: 6px;
   color: var(--lg-primary);
+  margin-top: auto;
   margin-bottom: 24px;
 }
 .login-card {
   width: 100%;
   max-width: 420px;
+  margin-bottom: auto;
   background: #fff;
   border-radius: 22px;
   box-shadow: 0 24px 60px -20px rgba(22, 50, 92, 0.18), 0 2px 6px rgba(22, 50, 92, 0.04);

--- a/web/login/src/LoginApp.vue
+++ b/web/login/src/LoginApp.vue
@@ -332,7 +332,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 40px 16px;
+  padding: 32px 16px 160px;
 }
 .login-wordmark {
   font-size: 14px;

--- a/web/login/src/LoginApp.vue
+++ b/web/login/src/LoginApp.vue
@@ -119,6 +119,7 @@ export default {
     }
   },
   async mounted() {
+    this.setupKeyboard()
     // Handle logout path - clear Authelia session first
     if (window.location.pathname === '/logout') {
       try {
@@ -134,7 +135,39 @@ export default {
     this.flowID = params.get('flow_id') || ''
     this.checkState()
   },
+  beforeUnmount() {
+    const vv = window.visualViewport
+    if (vv && this.vvHandler) {
+      vv.removeEventListener('resize', this.vvHandler)
+      vv.removeEventListener('scroll', this.vvHandler)
+    }
+    if (this.focusHandler) {
+      document.removeEventListener('focusin', this.focusHandler)
+    }
+  },
   methods: {
+    setupKeyboard() {
+      const vv = window.visualViewport
+      if (!vv) return
+      this.vvHandler = () => {
+        const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
+        document.documentElement.style.setProperty('--kb', inset + 'px')
+        const active = document.activeElement
+        if (inset > 0 && active && active.tagName === 'INPUT') {
+          active.scrollIntoView({ block: 'center', behavior: 'smooth' })
+        }
+      }
+      vv.addEventListener('resize', this.vvHandler)
+      vv.addEventListener('scroll', this.vvHandler)
+      this.focusHandler = (e) => {
+        if (e.target && e.target.tagName === 'INPUT') {
+          setTimeout(() => {
+            e.target.scrollIntoView({ block: 'center', behavior: 'smooth' })
+          }, 300)
+        }
+      }
+      document.addEventListener('focusin', this.focusHandler)
+    },
     async checkState() {
       console.log('login: checkState, flowID=' + this.flowID + ', targetURL=' + this.targetURL)
       // For OIDC flows, always show login form (don't auto-complete)
@@ -332,7 +365,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 32px 16px 160px;
+  padding: 32px 16px calc(40px + var(--kb, 0px));
 }
 .login-wordmark {
   font-size: 14px;

--- a/web/login/src/main.js
+++ b/web/login/src/main.js
@@ -1,4 +1,12 @@
 import { createApp } from 'vue'
 import LoginApp from './LoginApp.vue'
 
-createApp(LoginApp).mount('#app')
+async function start () {
+  if (import.meta.env.VITE_STUB) {
+    const { mock } = await import('./stub/api')
+    mock()
+  }
+  createApp(LoginApp).mount('#app')
+}
+
+start()

--- a/web/login/src/stub/api.js
+++ b/web/login/src/stub/api.js
@@ -1,0 +1,43 @@
+import { createServer, Response } from 'miragejs'
+
+const state = {
+  authLevel: 0
+}
+
+export function mock () {
+  createServer({
+    routes () {
+      this.urlPrefix = ''
+
+      this.get('/api/state', () => {
+        return new Response(200, {}, { data: { authentication_level: state.authLevel } })
+      })
+
+      this.post('/api/firstfactor', (_schema, request) => {
+        const body = JSON.parse(request.requestBody || '{}')
+        if (body.username && body.password) {
+          return new Response(200, {}, { data: 'OK' })
+        }
+        return new Response(401, {}, { data: { message: 'Incorrect username or password' } })
+      })
+
+      this.post('/login/totp/status', () => {
+        return new Response(200, {}, { data: { configured: false } })
+      })
+
+      this.post('/login/totp/setup', () => {
+        return new Response(200, {}, { data: { uri: 'otpauth://totp/Syncloud:11?secret=STUBSTUBSTUBSTUB&issuer=Syncloud' } })
+      })
+
+      this.post('/api/secondfactor/totp', () => {
+        return new Response(200, {}, { data: 'OK' })
+      })
+
+      this.post('/api/logout', () => {
+        return new Response(200, {}, { data: 'OK' })
+      })
+
+      this.passthrough()
+    }
+  })
+}


### PR DESCRIPTION
## Problem

On mobile, tapping a field in the login form opened the keyboard and left a large empty gap above the card while the form slid partly under the keyboard — the form was only half visible.

**Root cause:** `.login-root` centered the card with `min-height: 100vh` + `justify-content: center`. `100vh` is the full *layout* viewport and does **not** shrink when the on-screen keyboard opens, so the card stayed centered in the full (tall) height. The keyboard then covered the lower half, pushing the visible portion of the form down and leaving dead space up top.

## Fix (best practice)

- Use **dynamic viewport units** (`100dvh`) with a `100vh` fallback. `dvh` shrinks as the keyboard/toolbars appear, so the card re-centers within the *visible* area — the form fills the space above the keyboard instead of hiding under it.
- Center via **auto margins** on the wordmark/card instead of `justify-content: center`. Auto margins collapse to `0` when content is taller than the viewport, so on short viewports (keyboard open on small phones) the form scrolls into view rather than being clipped at the top.

## dev:stub for web/login

The login form lives in `web/login` (the Authelia auth portal), a separate Vite app from `web/platform`. It had no stub, so previewing it required a real backend (and a live session would auto-redirect away).

Added `dev:stub` mirroring `web/platform`:
- `npm run dev:stub` (`VITE_STUB=1 vite`)
- `src/stub/api.js` — miragejs mock of `/api/state`, `/api/firstfactor`, `/login/totp/*`, `/api/secondfactor/totp`, `/api/logout`. `/api/state` returns `authentication_level: 0`, so the form shows and never auto-redirects.
- Stub is lazy-imported behind `import.meta.env.VITE_STUB`, so it is never loaded in production (same pattern as platform).

## Preview locally

```
cd web/login
npm install
npm run dev:stub
```

## Testing

- `npm run build` (prod) and `VITE_STUB=1 vite build` both succeed.
- `dev:stub` server boots and serves the form.