### PR TITLE
Mail relay: admin toggle, app credentials API, change hook

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -10,7 +10,7 @@ local bootstrap = '25.02';
 local nginx = '1.24.0';
 local python = '3.12-slim-bookworm';
 local alpine = '3.21';
-local visual_diff_skip_build = '3004';
+local visual_diff_skip_build = '3040';
 
 local build(arch, testUI) = [{
   kind: 'pipeline',

--- a/backend/config/user_config.go
+++ b/backend/config/user_config.go
@@ -62,6 +62,14 @@ func (c *UserConfig) SetRelayEnabled(enabled bool) {
 	c.db.UpsertBool("platform.relay_enabled", enabled)
 }
 
+func (c *UserConfig) IsMailRelayEnabled() bool {
+	return c.db.GetBool("platform.mail_relay_enabled", false)
+}
+
+func (c *UserConfig) SetMailRelayEnabled(enabled bool) {
+	c.db.UpsertBool("platform.mail_relay_enabled", enabled)
+}
+
 func (c *UserConfig) IsRedirectEnabled() bool {
 	return c.db.GetBool("platform.redirect_enabled", false)
 }

--- a/backend/event/trigger.go
+++ b/backend/event/trigger.go
@@ -31,6 +31,10 @@ func (t *Trigger) RunAccessChangeEvent() error {
 	return t.RunEventOnAllApps("access-change")
 }
 
+func (t *Trigger) RunMailRelayChangeEvent() error {
+	return t.RunEventOnAllApps("mail-relay-change")
+}
+
 func (t *Trigger) RunCertificateChangeEvent() error {
 	return t.RunEventOnAllApps("certificate-change")
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.11.1
-	github.com/syncloud/golib v1.1.15
+	github.com/syncloud/golib v1.1.21
 	go.uber.org/zap v1.25.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/image v0.23.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -256,6 +256,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syncloud/golib v1.1.15 h1:NuWw/BOJ+0maoU775HxrlpvXdAWrFvRnn5X2gPhRBxA=
 github.com/syncloud/golib v1.1.15/go.mod h1:XmmoqNuegLnl27FbmzLj60dTR/tN7c1X7Qp3uUPRC88=
+github.com/syncloud/golib v1.1.21 h1:UpNlcB0lREN3TrZaeCidskutEdArt1oQMgU4/eoBpn8=
+github.com/syncloud/golib v1.1.21/go.mod h1:XmmoqNuegLnl27FbmzLj60dTR/tN7c1X7Qp3uUPRC88=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/backend/redirect/model.go
+++ b/backend/redirect/model.go
@@ -56,6 +56,7 @@ type FreeDomainUpdateRequest struct {
 	LocalIp         *string `json:"local_ip,omitempty"`
 	MapLocalAddress bool    `json:"map_local_address,omitempty"`
 	Relay           bool    `json:"relay,omitempty"`
+	MailRelay       bool    `json:"mail_relay,omitempty"`
 	Token           string  `json:"token"`
 	Ipv6            *string `json:"ipv6,omitempty"`
 	DkimKey         *string `json:"dkim_key,omitempty"`

--- a/backend/redirect/redirect.go
+++ b/backend/redirect/redirect.go
@@ -16,6 +16,7 @@ import (
 type UserConfig interface {
 	GetDomainUpdateToken() *string
 	GetDkimKey() *string
+	IsMailRelayEnabled() bool
 }
 
 type RedirectConfig interface {
@@ -144,6 +145,7 @@ func (r *Service) Update(relay bool, ipv4 *string, port *int, ipv4Enabled bool, 
 		WebPort:         port,
 		WebLocalPort:    config.WebAccessPort,
 		Relay:           relay,
+		MailRelay:       r.userConfig.IsMailRelayEnabled(),
 		Ipv4Enabled:     ipv4Enabled,
 		Ipv6Enabled:     ipv6Enabled,
 	}

--- a/backend/redirect/redirect_test.go
+++ b/backend/redirect/redirect_test.go
@@ -25,6 +25,10 @@ func (u *UserConfigStub) GetDkimKey() *string {
 	return &key
 }
 
+func (u *UserConfigStub) IsMailRelayEnabled() bool {
+	return false
+}
+
 type RedirectStub struct{}
 
 func (r *RedirectStub) ApiUrl() string {

--- a/backend/rest/api.go
+++ b/backend/rest/api.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"fmt"
 	"github.com/gorilla/mux"
+	"github.com/syncloud/platform/rest/model"
 	"go.uber.org/zap"
 	"net"
 	"net/http"
@@ -14,10 +15,13 @@ type DeviceUserConfig interface {
 	SetDkimKey(key *string)
 	Url(app string) string
 	AppDomain(app string) string
+	IsMailRelayEnabled() bool
+	GetDomainUpdateToken() *string
 }
 
 type DeviceRedirect interface {
 	UserEmail() *string
+	Domain() string
 }
 
 type Storage interface {
@@ -76,6 +80,7 @@ func (a *Api) Start() error {
 	r.HandleFunc("/app/init_storage", a.mw.Handle(a.AppInitStorage)).Methods("POST")
 	r.HandleFunc("/config/get_dkim_key", a.mw.Handle(a.ConfigGetDkimKey)).Methods("GET")
 	r.HandleFunc("/config/set_dkim_key", a.mw.Handle(a.ConfigSetDkimKey)).Methods("POST")
+	r.HandleFunc("/mail/relay", a.mw.Handle(a.MailRelay)).Methods("GET")
 	r.HandleFunc("/service/restart", a.mw.Handle(a.ServiceRestart)).Methods("POST")
 	r.HandleFunc("/app/storage_dir", a.mw.Handle(a.AppStorageDir)).Methods("GET")
 	r.HandleFunc("/user/email", a.mw.Handle(a.UserEmail)).Methods("GET")
@@ -150,6 +155,20 @@ func (a *Api) RegisterOIDCClient(req *http.Request) (interface{}, error) {
 
 func (a *Api) ConfigGetDkimKey(_ *http.Request) (interface{}, error) {
 	return a.userConfig.GetDkimKey(), nil
+}
+
+func (a *Api) MailRelay(_ *http.Request) (interface{}, error) {
+	token := a.userConfig.GetDomainUpdateToken()
+	if !a.userConfig.IsMailRelayEnabled() || token == nil {
+		return &model.MailRelayCredentials{Enabled: false}, nil
+	}
+	return &model.MailRelayCredentials{
+		Enabled:  true,
+		Host:     fmt.Sprintf("mail-relay.%s", a.redirect.Domain()),
+		Port:     587,
+		Login:    a.userConfig.GetDeviceDomain(),
+		Password: *token,
+	}, nil
 }
 
 func (a *Api) ConfigSetDkimKey(req *http.Request) (interface{}, error) {

--- a/backend/rest/api.go
+++ b/backend/rest/api.go
@@ -165,7 +165,7 @@ func (a *Api) MailRelay(_ *http.Request) (interface{}, error) {
 	return &model.MailRelayCredentials{
 		Enabled:  true,
 		Host:     fmt.Sprintf("mail-relay.%s", a.redirect.Domain()),
-		Port:     587,
+		Port:     465,
 		Login:    a.userConfig.GetDeviceDomain(),
 		Password: *token,
 	}, nil

--- a/backend/rest/api_test.go
+++ b/backend/rest/api_test.go
@@ -43,7 +43,7 @@ func TestMailRelay_Enabled(t *testing.T) {
 
 	assert.True(t, credentials.Enabled)
 	assert.Equal(t, "mail-relay.syncloud.it", credentials.Host)
-	assert.Equal(t, 587, credentials.Port)
+	assert.Equal(t, 465, credentials.Port)
 	assert.Equal(t, "device.syncloud.it", credentials.Login)
 	assert.Equal(t, token, credentials.Password)
 }

--- a/backend/rest/api_test.go
+++ b/backend/rest/api_test.go
@@ -1,0 +1,69 @@
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/syncloud/platform/rest/model"
+)
+
+type fakeMailRelayUserConfig struct {
+	DeviceUserConfig
+	domain       string
+	relayEnabled bool
+	token        *string
+}
+
+func (f *fakeMailRelayUserConfig) GetDeviceDomain() string       { return f.domain }
+func (f *fakeMailRelayUserConfig) IsMailRelayEnabled() bool      { return f.relayEnabled }
+func (f *fakeMailRelayUserConfig) GetDomainUpdateToken() *string { return f.token }
+
+type fakeMailRelayRedirect struct {
+	DeviceRedirect
+	domain string
+}
+
+func (f *fakeMailRelayRedirect) Domain() string { return f.domain }
+
+func mailRelay(t *testing.T, userConfig DeviceUserConfig, redirect DeviceRedirect) *model.MailRelayCredentials {
+	t.Helper()
+	api := &Api{userConfig: userConfig, redirect: redirect}
+	response, err := api.MailRelay(nil)
+	assert.NoError(t, err)
+	credentials, ok := response.(*model.MailRelayCredentials)
+	assert.True(t, ok)
+	return credentials
+}
+
+func TestMailRelay_Enabled(t *testing.T) {
+	token := "the-token"
+	credentials := mailRelay(t,
+		&fakeMailRelayUserConfig{domain: "device.syncloud.it", relayEnabled: true, token: &token},
+		&fakeMailRelayRedirect{domain: "syncloud.it"})
+
+	assert.True(t, credentials.Enabled)
+	assert.Equal(t, "mail-relay.syncloud.it", credentials.Host)
+	assert.Equal(t, 587, credentials.Port)
+	assert.Equal(t, "device.syncloud.it", credentials.Login)
+	assert.Equal(t, token, credentials.Password)
+}
+
+func TestMailRelay_DisabledByToggle(t *testing.T) {
+	token := "the-token"
+	credentials := mailRelay(t,
+		&fakeMailRelayUserConfig{domain: "device.syncloud.it", relayEnabled: false, token: &token},
+		&fakeMailRelayRedirect{domain: "syncloud.it"})
+
+	assert.False(t, credentials.Enabled)
+	assert.Empty(t, credentials.Host)
+	assert.Empty(t, credentials.Password)
+}
+
+func TestMailRelay_DisabledWithoutToken(t *testing.T) {
+	credentials := mailRelay(t,
+		&fakeMailRelayUserConfig{domain: "device.syncloud.it", relayEnabled: true, token: nil},
+		&fakeMailRelayRedirect{domain: "syncloud.it"})
+
+	assert.False(t, credentials.Enabled)
+	assert.Empty(t, credentials.Password)
+}

--- a/backend/rest/backend.go
+++ b/backend/rest/backend.go
@@ -195,6 +195,8 @@ func (b *Backend) Start() error {
 	r.HandleFunc("/rest/certificate/log", b.mw.FailIfNotActivated(b.mw.AdminSecuredHandle(b.certificate.CertificateLog))).Methods("GET")
 	r.HandleFunc("/rest/access", b.mw.FailIfNotActivated(b.mw.AdminSecuredHandle(b.GetAccess))).Methods("GET")
 	r.HandleFunc("/rest/access", b.mw.FailIfNotActivated(b.mw.AdminSecuredHandle(b.SetAccess))).Methods("POST")
+	r.HandleFunc("/rest/mail_relay", b.mw.FailIfNotActivated(b.mw.AdminSecuredHandle(b.GetMailRelay))).Methods("GET")
+	r.HandleFunc("/rest/mail_relay", b.mw.FailIfNotActivated(b.mw.AdminSecuredHandle(b.SetMailRelay))).Methods("POST")
 	r.HandleFunc("/rest/apps/available", b.mw.FailIfNotActivated(b.mw.AdminSecuredHandle(b.AppsAvailable))).Methods("GET")
 	r.HandleFunc("/rest/apps/installed", b.mw.FailIfNotActivated(b.mw.SecuredHandle(b.AppsInstalled))).Methods("GET")
 	r.HandleFunc("/rest/app/install", b.mw.FailIfNotActivated(b.mw.AdminSecuredHandle(b.AppInstall))).Methods("POST")
@@ -440,6 +442,22 @@ func (b *Backend) GetAccess(_ *http.Request) (interface{}, error) {
 
 func (b *Backend) IsActivated(_ *http.Request) (interface{}, error) {
 	return b.userConfig.IsActivated(), nil
+}
+
+func (b *Backend) GetMailRelay(_ *http.Request) (interface{}, error) {
+	return &model.MailRelay{Enabled: b.userConfig.IsMailRelayEnabled()}, nil
+}
+
+func (b *Backend) SetMailRelay(req *http.Request) (interface{}, error) {
+	var request model.MailRelay
+	if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+		return nil, errors.New("mail relay request is wrong")
+	}
+	b.userConfig.SetMailRelayEnabled(request.Enabled)
+	if err := b.eventTrigger.RunMailRelayChangeEvent(); err != nil {
+		return nil, err
+	}
+	return request, nil
 }
 
 func (b *Backend) SetAccess(req *http.Request) (interface{}, error) {

--- a/backend/rest/backend.go
+++ b/backend/rest/backend.go
@@ -454,6 +454,9 @@ func (b *Backend) SetMailRelay(req *http.Request) (interface{}, error) {
 		return nil, errors.New("mail relay request is wrong")
 	}
 	b.userConfig.SetMailRelayEnabled(request.Enabled)
+	if err := b.externalAddress.Sync(); err != nil {
+		return nil, err
+	}
 	if err := b.eventTrigger.RunMailRelayChangeEvent(); err != nil {
 		return nil, err
 	}

--- a/backend/rest/model/model.go
+++ b/backend/rest/model/model.go
@@ -21,6 +21,18 @@ func (a Access) Ipv4PublicDirect() bool {
 	return a.Ipv4Public && !a.RelayEnabled
 }
 
+type MailRelay struct {
+	Enabled bool `json:"enabled"`
+}
+
+type MailRelayCredentials struct {
+	Enabled  bool   `json:"enabled"`
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Login    string `json:"login,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
 type RedirectInfoResponse struct {
 	Domain string `json:"domain"`
 }

--- a/test/testapp/cli/go.mod
+++ b/test/testapp/cli/go.mod
@@ -2,7 +2,7 @@ module testapp
 
 go 1.20
 
-require github.com/syncloud/golib v1.1.17
+require github.com/syncloud/golib v1.1.21
 
 require (
 	go.uber.org/multierr v1.10.0 // indirect

--- a/test/testapp/cli/go.sum
+++ b/test/testapp/cli/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/syncloud/golib v1.1.17 h1:/TddxLOGa8ujEb6DahvVC9UP6onDAwfR85+JDqZfSqc=
 github.com/syncloud/golib v1.1.17/go.mod h1:XmmoqNuegLnl27FbmzLj60dTR/tN7c1X7Qp3uUPRC88=
+github.com/syncloud/golib v1.1.21 h1:UpNlcB0lREN3TrZaeCidskutEdArt1oQMgU4/eoBpn8=
+github.com/syncloud/golib v1.1.21/go.mod h1:XmmoqNuegLnl27FbmzLj60dTR/tN7c1X7Qp3uUPRC88=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/test/testapp/cli/installer/installer.go
+++ b/test/testapp/cli/installer/installer.go
@@ -67,7 +67,7 @@ func UpdateConfigs() error {
 		return err
 	}
 
-	clientSecret, err := client.RegisterOIDCClient(App, "/oidc/callback", false, "client_secret_basic")
+	clientSecret, err := client.RegisterOIDCClient(App, []string{"/oidc/callback"}, false, "client_secret_basic")
 	if err != nil {
 		return err
 	}

--- a/web/e2e/helpers/login.ts
+++ b/web/e2e/helpers/login.ts
@@ -6,12 +6,29 @@ const devicePassword = process.env.PLAYWRIGHT_DEVICE_PASSWORD ?? 'Password1'
 
 export { deviceUser, devicePassword, waitForLoading }
 
+const loginAttempts = 3
+
 export async function login(page: Page, opts: { user?: string; password?: string } = {}) {
-  await page.goto('/')
-  await page.locator('#username-textfield').fill(opts.user ?? deviceUser)
-  await page.locator('#password-textfield').fill(opts.password ?? devicePassword)
-  await page.locator('#sign-in-button').click()
-  await expect(page.getByRole('heading', { name: 'Applications' })).toBeVisible()
+  const applications = page.getByRole('heading', { name: 'Applications' })
+  for (let attempt = 1; attempt <= loginAttempts; attempt++) {
+    await page.goto('/')
+    if (await applications.isVisible()) {
+      break
+    }
+    const firstFactor = page
+      .waitForResponse(response => response.url().includes('/api/firstfactor'), { timeout: 30000 })
+      .catch(() => null)
+    await page.locator('#username-textfield').fill(opts.user ?? deviceUser)
+    await page.locator('#password-textfield').fill(opts.password ?? devicePassword)
+    await page.locator('#sign-in-button').click()
+    const response = await firstFactor
+    if (response !== null && response.status() >= 500 && attempt < loginAttempts) {
+      await page.waitForTimeout(2000)
+      continue
+    }
+    await expect(applications).toBeVisible()
+    break
+  }
   await waitForLoading(page)
 }
 

--- a/web/e2e/helpers/login.ts
+++ b/web/e2e/helpers/login.ts
@@ -6,24 +6,35 @@ const devicePassword = process.env.PLAYWRIGHT_DEVICE_PASSWORD ?? 'Password1'
 
 export { deviceUser, devicePassword, waitForLoading }
 
-const loginAttempts = 3
+const loginAttempts = 2
+const formTimeout = 5000
+const firstFactorTimeout = 10000
 
 export async function login(page: Page, opts: { user?: string; password?: string } = {}) {
   const applications = page.getByRole('heading', { name: 'Applications' })
+  const username = page.locator('#username-textfield')
   for (let attempt = 1; attempt <= loginAttempts; attempt++) {
+    const last = attempt === loginAttempts
     await page.goto('/')
     if (await applications.isVisible()) {
       break
     }
+    try {
+      await expect(username).toBeVisible({ timeout: formTimeout })
+    } catch (e) {
+      if (last) {
+        throw e
+      }
+      continue
+    }
     const firstFactor = page
-      .waitForResponse(response => response.url().includes('/api/firstfactor'), { timeout: 30000 })
+      .waitForResponse(response => response.url().includes('/api/firstfactor'), { timeout: firstFactorTimeout })
       .catch(() => null)
-    await page.locator('#username-textfield').fill(opts.user ?? deviceUser)
+    await username.fill(opts.user ?? deviceUser)
     await page.locator('#password-textfield').fill(opts.password ?? devicePassword)
     await page.locator('#sign-in-button').click()
     const response = await firstFactor
-    if (response !== null && response.status() >= 500 && attempt < loginAttempts) {
-      await page.waitForTimeout(2000)
+    if (!last && response !== null && response.status() >= 500) {
       continue
     }
     await expect(applications).toBeVisible()

--- a/web/platform/src/locales/ar.json
+++ b/web/platform/src/locales/ar.json
@@ -50,7 +50,8 @@
     "customProxy": "وكيل مخصص",
     "system": "النظام",
     "locale": "الإعدادات الإقليمية",
-    "health": "الصحة"
+    "health": "الصحة",
+    "email": "البريد"
   },
   "activation": {
     "title": "التفعيل",
@@ -350,5 +351,11 @@
     "kindPressure": "تم اكتشاف ضغط على الذاكرة",
     "kindVictimSigterm": "تم إنهاء العملية (SIGTERM)",
     "kindVictimSigkill": "تم قتل العملية (SIGKILL)"
+  },
+  "email": {
+    "title": "البريد",
+    "relay": "مُرحّل بريد Syncloud",
+    "relayDescription": "إرسال البريد الصادر عبر Syncloud حتى تقبله مزودات البريد الكبرى. يتطلب اشتراكًا نشطًا.",
+    "save": "حفظ"
   }
 }

--- a/web/platform/src/locales/ar.json
+++ b/web/platform/src/locales/ar.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "يُفعّل سجل DNS لـ IP v6. تتحقق خدمة DNS الخاصة بـ Syncloud من اتصال الجهاز (إمكانية الوصول إلى الإنترنت) عند الحفظ للراحة.",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "الوصول إلى جهازك من أي مكان دون إعداد الموجّه، ويعمل حتى خلف CGNAT. تُطبَّق حدود استخدام شهرية بحسب باقتك.",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "البريد",
     "relay": "مُرحّل بريد Syncloud",
-    "relayDescription": "إرسال البريد الصادر عبر Syncloud حتى تقبله مزودات البريد الكبرى. يتطلب اشتراكًا نشطًا.",
+    "relayDescription": "إرسال البريد الصادر عبر Syncloud حتى تقبله مزودات البريد الكبرى. تُطبَّق حدود إرسال شهرية بحسب باقتك.",
     "save": "حفظ"
   }
 }

--- a/web/platform/src/locales/de.json
+++ b/web/platform/src/locales/de.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "Aktiviert den IP v6 DNS-Eintrag. Der Syncloud DNS-Dienst prüft beim Speichern die Geräteverbindung (Internet-Zugänglichkeit).",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "Erreichen Sie Ihr Gerät von überall — ohne Router-Einrichtung, auch hinter CGNAT. Es gelten monatliche Nutzungsgrenzen je nach Tarif.",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "E-Mail",
     "relay": "Syncloud-Mail-Relay",
-    "relayDescription": "Ausgehende E-Mails über Syncloud senden, damit große Anbieter sie akzeptieren. Erfordert ein aktives Abonnement.",
+    "relayDescription": "Ausgehende E-Mails über Syncloud senden, damit große Anbieter sie akzeptieren. Es gelten monatliche Sendelimits je nach Tarif.",
     "save": "Speichern"
   }
 }

--- a/web/platform/src/locales/de.json
+++ b/web/platform/src/locales/de.json
@@ -50,7 +50,8 @@
     "customProxy": "Benutzerdefinierter Proxy",
     "system": "System",
     "locale": "Regional",
-    "health": "Gesundheit"
+    "health": "Gesundheit",
+    "email": "E-Mail"
   },
   "activation": {
     "title": "Aktivierung",
@@ -350,5 +351,11 @@
     "kindPressure": "Speicherengpass erkannt",
     "kindVictimSigterm": "Prozess beendet (SIGTERM)",
     "kindVictimSigkill": "Prozess gekillt (SIGKILL)"
+  },
+  "email": {
+    "title": "E-Mail",
+    "relay": "Syncloud-Mail-Relay",
+    "relayDescription": "Ausgehende E-Mails über Syncloud senden, damit große Anbieter sie akzeptieren. Erfordert ein aktives Abonnement.",
+    "save": "Speichern"
   }
 }

--- a/web/platform/src/locales/en.json
+++ b/web/platform/src/locales/en.json
@@ -57,7 +57,8 @@
     "customProxy": "Custom Proxy",
     "system": "System",
     "locale": "Locale",
-    "health": "Health"
+    "health": "Health",
+    "email": "Email"
   },
   "health": {
     "title": "Health",
@@ -350,5 +351,11 @@
       "deviceCredentialsText": "Device credentials are used to access your device and all the apps (as admin user). They are stored on device and no one knows them. If you forget them you will need to reactivate your device."
     },
     "deviceNameSub": "Choose the name your device will be reachable by."
+  },
+  "email": {
+    "title": "Email",
+    "relay": "Syncloud mail relay",
+    "relayDescription": "Send outgoing email through Syncloud so major providers accept it. Requires an active subscription.",
+    "save": "Save"
   }
 }

--- a/web/platform/src/locales/en.json
+++ b/web/platform/src/locales/en.json
@@ -276,7 +276,7 @@
   "access": {
     "title": "Access",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Monthly usage limits apply and depend on your plan.",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "Email",
     "relay": "Syncloud mail relay",
-    "relayDescription": "Send outgoing email through Syncloud so major providers accept it. Requires an active subscription.",
+    "relayDescription": "Send outgoing email through Syncloud so major providers accept it. Monthly sending limits apply and depend on your plan.",
     "save": "Save"
   }
 }

--- a/web/platform/src/locales/es.json
+++ b/web/platform/src/locales/es.json
@@ -50,7 +50,8 @@
     "customProxy": "Proxy personalizado",
     "system": "Sistema",
     "locale": "Regional",
-    "health": "Salud"
+    "health": "Salud",
+    "email": "Correo"
   },
   "activation": {
     "title": "Activación",
@@ -350,5 +351,11 @@
     "kindPressure": "presión de memoria detectada",
     "kindVictimSigterm": "proceso terminado (SIGTERM)",
     "kindVictimSigkill": "proceso matado (SIGKILL)"
+  },
+  "email": {
+    "title": "Correo",
+    "relay": "Relé de correo de Syncloud",
+    "relayDescription": "Enviar el correo saliente a través de Syncloud para que los grandes proveedores lo acepten. Requiere una suscripción activa.",
+    "save": "Guardar"
   }
 }

--- a/web/platform/src/locales/es.json
+++ b/web/platform/src/locales/es.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "Activa el registro DNS IP v6. El servicio DNS de Syncloud verifica la conexión del dispositivo (accesibilidad desde internet) por conveniencia al guardar.",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "Acceda a su dispositivo desde cualquier lugar, sin configurar el router e incluso detrás de CGNAT. Se aplican límites mensuales de uso según su plan.",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "Correo",
     "relay": "Relé de correo de Syncloud",
-    "relayDescription": "Enviar el correo saliente a través de Syncloud para que los grandes proveedores lo acepten. Requiere una suscripción activa.",
+    "relayDescription": "Enviar el correo saliente a través de Syncloud para que los grandes proveedores lo acepten. Se aplican límites mensuales de envío según su plan.",
     "save": "Guardar"
   }
 }

--- a/web/platform/src/locales/fr.json
+++ b/web/platform/src/locales/fr.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "Active l'enregistrement DNS IP v6. Le service DNS Syncloud vérifie la connexion de l'appareil (accessibilité internet) par commodité lors de l'enregistrement.",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "Accédez à votre appareil depuis n'importe où, sans configuration du routeur et même derrière un CGNAT. Des limites d'utilisation mensuelles s'appliquent selon votre forfait.",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "E-mail",
     "relay": "Relais de messagerie Syncloud",
-    "relayDescription": "Envoyer le courrier sortant via Syncloud afin que les grands fournisseurs l'acceptent. Nécessite un abonnement actif.",
+    "relayDescription": "Envoyer le courrier sortant via Syncloud afin que les grands fournisseurs l'acceptent. Des limites d'envoi mensuelles s'appliquent selon votre forfait.",
     "save": "Enregistrer"
   }
 }

--- a/web/platform/src/locales/fr.json
+++ b/web/platform/src/locales/fr.json
@@ -50,7 +50,8 @@
     "customProxy": "Proxy personnalisé",
     "system": "Système",
     "locale": "Régional",
-    "health": "Santé"
+    "health": "Santé",
+    "email": "E-mail"
   },
   "activation": {
     "title": "Activation",
@@ -350,5 +351,11 @@
     "kindPressure": "pression mémoire détectée",
     "kindVictimSigterm": "processus terminé (SIGTERM)",
     "kindVictimSigkill": "processus tué (SIGKILL)"
+  },
+  "email": {
+    "title": "E-mail",
+    "relay": "Relais de messagerie Syncloud",
+    "relayDescription": "Envoyer le courrier sortant via Syncloud afin que les grands fournisseurs l'acceptent. Nécessite un abonnement actif.",
+    "save": "Enregistrer"
   }
 }

--- a/web/platform/src/locales/hi.json
+++ b/web/platform/src/locales/hi.json
@@ -50,7 +50,8 @@
     "customProxy": "कस्टम प्रॉक्सी",
     "system": "सिस्टम",
     "locale": "क्षेत्रीय",
-    "health": "स्वास्थ्य"
+    "health": "स्वास्थ्य",
+    "email": "ईमेल"
   },
   "activation": {
     "title": "सक्रियण",
@@ -350,5 +351,11 @@
     "kindPressure": "मेमोरी दबाव का पता चला",
     "kindVictimSigterm": "प्रक्रिया समाप्त (SIGTERM)",
     "kindVictimSigkill": "प्रक्रिया मार दी गई (SIGKILL)"
+  },
+  "email": {
+    "title": "ईमेल",
+    "relay": "Syncloud मेल रिले",
+    "relayDescription": "आउटगोइंग ईमेल Syncloud के माध्यम से भेजें ताकि बड़े प्रदाता उसे स्वीकार करें। सक्रिय सदस्यता आवश्यक है।",
+    "save": "सहेजें"
   }
 }

--- a/web/platform/src/locales/hi.json
+++ b/web/platform/src/locales/hi.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "IP v6 DNS रिकॉर्ड सक्षम करता है। Syncloud DNS सेवा सुविधा के लिए सहेजने पर डिवाइस कनेक्शन (इंटरनेट पहुँच) की पुष्टि करती है।",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "कहीं से भी अपने डिवाइस तक पहुँचें — राउटर सेटअप के बिना, CGNAT के पीछे भी काम करता है। आपकी योजना के अनुसार मासिक उपयोग सीमाएँ लागू होती हैं।",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "ईमेल",
     "relay": "Syncloud मेल रिले",
-    "relayDescription": "आउटगोइंग ईमेल Syncloud के माध्यम से भेजें ताकि बड़े प्रदाता उसे स्वीकार करें। सक्रिय सदस्यता आवश्यक है।",
+    "relayDescription": "आउटगोइंग ईमेल Syncloud के माध्यम से भेजें ताकि बड़े प्रदाता उसे स्वीकार करें। आपकी योजना के अनुसार मासिक भेजने की सीमाएँ लागू होती हैं।",
     "save": "सहेजें"
   }
 }

--- a/web/platform/src/locales/ja.json
+++ b/web/platform/src/locales/ja.json
@@ -50,7 +50,8 @@
     "customProxy": "カスタムプロキシ",
     "system": "システム",
     "locale": "ロケール",
-    "health": "ヘルス"
+    "health": "ヘルス",
+    "email": "メール"
   },
   "activation": {
     "title": "アクティベーション",
@@ -350,5 +351,11 @@
     "kindPressure": "メモリ圧迫を検出",
     "kindVictimSigterm": "プロセス終了 (SIGTERM)",
     "kindVictimSigkill": "プロセス強制終了 (SIGKILL)"
+  },
+  "email": {
+    "title": "メール",
+    "relay": "Syncloud メールリレー",
+    "relayDescription": "送信メールを Syncloud 経由で送信し、主要プロバイダーに受け入れられるようにします。有効なサブスクリプションが必要です。",
+    "save": "保存"
   }
 }

--- a/web/platform/src/locales/ja.json
+++ b/web/platform/src/locales/ja.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "IP v6 DNS レコードを有効にします。Syncloud DNS サービスは保存時にデバイス接続(インターネットアクセス性)を便宜的に確認します。",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "ルーター設定なしで、CGNAT 環境でもどこからでもデバイスにアクセスできます。プランに応じた月間の利用上限が適用されます。",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "メール",
     "relay": "Syncloud メールリレー",
-    "relayDescription": "送信メールを Syncloud 経由で送信し、主要プロバイダーに受け入れられるようにします。有効なサブスクリプションが必要です。",
+    "relayDescription": "送信メールを Syncloud 経由で送信し、主要プロバイダーに受け入れられるようにします。プランに応じた月間の送信上限が適用されます。",
     "save": "保存"
   }
 }

--- a/web/platform/src/locales/pt.json
+++ b/web/platform/src/locales/pt.json
@@ -50,7 +50,8 @@
     "customProxy": "Proxy personalizado",
     "system": "Sistema",
     "locale": "Regional",
-    "health": "Saúde"
+    "health": "Saúde",
+    "email": "E-mail"
   },
   "activation": {
     "title": "Ativação",
@@ -350,5 +351,11 @@
     "kindPressure": "pressão de memória detectada",
     "kindVictimSigterm": "processo encerrado (SIGTERM)",
     "kindVictimSigkill": "processo morto (SIGKILL)"
+  },
+  "email": {
+    "title": "E-mail",
+    "relay": "Retransmissão de e-mail Syncloud",
+    "relayDescription": "Enviar e-mails de saída através do Syncloud para que os grandes provedores os aceitem. Requer uma assinatura ativa.",
+    "save": "Salvar"
   }
 }

--- a/web/platform/src/locales/pt.json
+++ b/web/platform/src/locales/pt.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "Ativa o registro DNS IP v6. O serviço de DNS do Syncloud verifica a conexão do dispositivo (acessibilidade à internet) por conveniência ao salvar.",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "Aceda ao seu dispositivo a partir de qualquer lugar, sem configurar o router e mesmo atrás de CGNAT. Aplicam-se limites mensais de utilização consoante o seu plano.",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "E-mail",
     "relay": "Retransmissão de e-mail Syncloud",
-    "relayDescription": "Enviar e-mails de saída através do Syncloud para que os grandes provedores os aceitem. Requer uma assinatura ativa.",
+    "relayDescription": "Enviar e-mails de saída através do Syncloud para que os grandes provedores os aceitem. Aplicam-se limites mensais de envio consoante o seu plano.",
     "save": "Salvar"
   }
 }

--- a/web/platform/src/locales/ru.json
+++ b/web/platform/src/locales/ru.json
@@ -50,7 +50,8 @@
     "customProxy": "Свой прокси",
     "system": "Система",
     "locale": "Регион",
-    "health": "Здоровье"
+    "health": "Здоровье",
+    "email": "Почта"
   },
   "activation": {
     "title": "Активация",
@@ -350,5 +351,11 @@
     "kindPressure": "обнаружена нехватка памяти",
     "kindVictimSigterm": "процесс завершён (SIGTERM)",
     "kindVictimSigkill": "процесс убит (SIGKILL)"
+  },
+  "email": {
+    "title": "Почта",
+    "relay": "Почтовый релей Syncloud",
+    "relayDescription": "Отправлять исходящую почту через Syncloud, чтобы крупные провайдеры её принимали. Требуется активная подписка.",
+    "save": "Сохранить"
   }
 }

--- a/web/platform/src/locales/ru.json
+++ b/web/platform/src/locales/ru.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "Включает DNS-запись IP v6. Служба DNS Syncloud проверяет при сохранении подключение устройства (доступность из интернета).",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "Доступ к устройству откуда угодно — без настройки роутера, работает даже за CGNAT. Действуют месячные лимиты использования в зависимости от тарифа.",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "Почта",
     "relay": "Почтовый релей Syncloud",
-    "relayDescription": "Отправлять исходящую почту через Syncloud, чтобы крупные провайдеры её принимали. Требуется активная подписка.",
+    "relayDescription": "Отправлять исходящую почту через Syncloud, чтобы крупные провайдеры её принимали. Действуют месячные лимиты отправки в зависимости от тарифа.",
     "save": "Сохранить"
   }
 }

--- a/web/platform/src/locales/zh-CN.json
+++ b/web/platform/src/locales/zh-CN.json
@@ -260,7 +260,7 @@
     "ipv6Title": "IP v6",
     "ipv6Text": "启用 IP v6 DNS 记录。Syncloud DNS 服务在保存时会为方便起见验证设备连接(互联网可访问性)。",
     "relay": "Syncloud Relay",
-    "relayDescription": "Reach your device from anywhere — no router setup, works even behind CGNAT. Included with an active subscription.",
+    "relayDescription": "无需配置路由器，即使在 CGNAT 环境下也能随时随地访问您的设备。将根据您的套餐适用每月用量上限。",
     "relayConnected": "Connected via relay",
     "relayUpgrade": "Approaching your limit — upgrade to Max",
     "relayInfoTitle": "Syncloud Relay",
@@ -355,7 +355,7 @@
   "email": {
     "title": "邮件",
     "relay": "Syncloud 邮件中继",
-    "relayDescription": "通过 Syncloud 发送外发邮件，以便主流服务商接受。需要有效的订阅。",
+    "relayDescription": "通过 Syncloud 发送外发邮件，以便主流服务商接受。将根据您的套餐适用每月发送上限。",
     "save": "保存"
   }
 }

--- a/web/platform/src/locales/zh-CN.json
+++ b/web/platform/src/locales/zh-CN.json
@@ -50,7 +50,8 @@
     "customProxy": "自定义代理",
     "system": "系统",
     "locale": "区域设置",
-    "health": "健康"
+    "health": "健康",
+    "email": "邮件"
   },
   "activation": {
     "title": "激活",
@@ -350,5 +351,11 @@
     "kindPressure": "检测到内存压力",
     "kindVictimSigterm": "进程已终止 (SIGTERM)",
     "kindVictimSigkill": "进程被强制结束 (SIGKILL)"
+  },
+  "email": {
+    "title": "邮件",
+    "relay": "Syncloud 邮件中继",
+    "relayDescription": "通过 Syncloud 发送外发邮件，以便主流服务商接受。需要有效的订阅。",
+    "save": "保存"
   }
 }

--- a/web/platform/src/router/index.js
+++ b/web/platform/src/router/index.js
@@ -12,6 +12,7 @@ const routes = [
   { path: '/backup', name: 'Backup', component: () => import('../views/Backup.vue'), meta: { admin: true } },
   { path: '/network', name: 'Network', component: () => import('../views/Network.vue'), meta: { admin: true } },
   { path: '/access', name: 'Access', component: () => import('../views/Access.vue'), meta: { admin: true } },
+  { path: '/email', name: 'Email', component: () => import('../views/Email.vue'), meta: { admin: true } },
   { path: '/storage', name: 'Storage', component: () => import('../views/Storage.vue'), meta: { admin: true } },
   { path: '/internalmemory', name: 'InternalMemory', component: () => import('../views/InternalMemory.vue'), meta: { admin: true } },
   { path: '/updates', name: 'Updates', component: () => import('../views/Updates.vue'), meta: { admin: true } },

--- a/web/platform/src/stub/api.js
+++ b/web/platform/src/stub/api.js
@@ -341,6 +341,14 @@ export function mock () {
         state.twoFactorEnabled = attrs.enabled
         return new Response(200, {}, { success: true, data: 'OK' })
       })
+      this.get('/rest/mail_relay', function (_schema, _request) {
+        return new Response(200, {}, { success: true, data: { enabled: state.mailRelayEnabled || false } })
+      })
+      this.post('/rest/mail_relay', function (_schema, request) {
+        const attrs = JSON.parse(request.requestBody)
+        state.mailRelayEnabled = attrs.enabled
+        return new Response(200, {}, { success: true, data: 'OK' })
+      })
       this.get('/rest/user', function (_schema, _request) {
         if (!state.activated) {
           return new Response(501, {}, { message: 'Not activated' })

--- a/web/platform/src/views/Email.vue
+++ b/web/platform/src/views/Email.vue
@@ -81,3 +81,35 @@ export default {
   }
 }
 </script>
+<style scoped>
+.access-block {
+  border: 1px solid var(--sc-border);
+  border-radius: 16px;
+  padding: 20px 22px;
+  margin-bottom: 16px;
+  background: var(--sc-surface);
+}
+.access-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.access-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.access-name {
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--sc-ink);
+}
+.detail-desc {
+  color: var(--sc-muted);
+  font-size: 14px;
+  margin: 8px 0 0;
+  max-width: 460px;
+  line-height: 1.5;
+}
+</style>

--- a/web/platform/src/views/Email.vue
+++ b/web/platform/src/views/Email.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="sc-page">
+    <div class="sc-card" id="block1">
+      <h1 class="sc-title">{{ $t('email.title') }}</h1>
+      <div :style="{ visibility: visibility }">
+
+        <div class="access-block" data-testid="mail-relay-section">
+          <div class="access-head">
+            <div class="access-heading">
+              <span class="access-name">{{ $t('email.relay') }}</span>
+            </div>
+            <s-switch id="tgl_mail_relay" data-testid="mail-relay-toggle" size="large" v-model="relayEnabled"
+                      style="--el-switch-on-color: #2faa5d"/>
+          </div>
+          <p class="detail-desc">{{ $t('email.relayDescription') }}</p>
+        </div>
+
+        <div class="sc-actions">
+          <button class="sc-btn sc-btn-success" id="btn_save" data-testid="mail-relay-save" type="submit"
+                  @click="save">{{ $t('email.save') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <Error ref="error"/>
+</template>
+
+<script>
+import Error from '../components/Error.vue'
+import axios from 'axios'
+import Loading from '../util/loading'
+
+export default {
+  name: 'Email',
+  data () {
+    return {
+      relayEnabled: undefined,
+      visibility: 'hidden',
+      loading: undefined
+    }
+  },
+  components: {
+    Error
+  },
+  mounted () {
+    this.progressShow()
+    this.reload()
+  },
+  methods: {
+    progressShow (text) {
+      this.loading = Loading.service({ lock: true, text: text || this.$t('common.loading'), background: 'rgba(0, 0, 0, 0.7)' })
+    },
+    progressHide () {
+      this.visibility = 'visible'
+      this.loading.close()
+    },
+    reload () {
+      axios.get('/rest/mail_relay')
+        .then(resp => {
+          this.relayEnabled = resp.data.data.enabled
+          this.progressHide()
+        })
+        .catch(e => {
+          this.$refs.error.showAxios(e)
+          this.progressHide()
+        })
+    },
+    save () {
+      this.progressShow()
+      axios.post('/rest/mail_relay', { enabled: this.relayEnabled })
+        .then(() => {
+          this.progressHide()
+          this.reload()
+        })
+        .catch(e => {
+          this.$refs.error.showAxios(e)
+          this.progressHide()
+        })
+    }
+  }
+}
+</script>

--- a/web/platform/src/views/Settings.vue
+++ b/web/platform/src/views/Settings.vue
@@ -19,6 +19,10 @@
           <i class="material-icons sc-tile-icon">cloud_queue</i>
           <div class="sc-tile-name">{{ $t('settings.access') }}</div>
         </router-link>
+        <router-link v-if="isAdmin" to="/email" id="email" data-testid="nav-email" class="sc-tile">
+          <i class="material-icons sc-tile-icon">mail_outline</i>
+          <div class="sc-tile-name">{{ $t('settings.email') }}</div>
+        </router-link>
         <router-link v-if="isAdmin" to="/internalmemory" id="internalmemory" class="sc-tile">
           <i class="material-icons sc-tile-icon">memory</i>
           <div class="sc-tile-name">{{ $t('settings.internalMemory') }}</div>


### PR DESCRIPTION
Device side of the **Syncloud mail relay** — a Syncloud-operated smarthost so outbound mail is accepted by providers that reject self-hosted senders on residential addresses, and by users whose ISP blocks port 25. See #553 and #567.

2 of 4 PRs: **platform** (this) · [golib](https://github.com/syncloud/golib/pull/2) · [mail](https://github.com/syncloud/mail/pull/4) · [redirect](https://github.com/syncloud/redirect/pull/59).

## Design

Authentication reuses what the device already has, exactly as the frp traffic relay does: the relay authenticates a device with its **domain update token as the SMTP password** and the **device domain as the login**. Nothing is provisioned, stored, or rotated, and redirect needs no new endpoint — the relay does the same token → domain lookup `relay/auth_server.go` already does.

## Changes

- **Setting**: `platform.mail_relay_enabled` in the config db, mirroring `platform.relay_enabled`.
- **Admin REST**: `GET`/`POST /rest/mail_relay` behind `FailIfNotActivated(AdminSecuredHandle(...))`. Saving persists the flag and fires a new `mail-relay-change` event on every installed app, so the mail app rewrites its postfix maps immediately.
- **App API**: `GET /mail/relay` on the app unix socket returns `{enabled, host, port, login, password}`, or `enabled:false` alone when the toggle is off or no domain token exists. Port is **465**, since the relay is reached with implicit TLS terminated by Caddy.
- **Event**: `Trigger.RunMailRelayChangeEvent()` via the existing generic `RunEventOnAllApps`.
- **UI**: a new admin-only **Email** page (`/email`) with the toggle, linked from Settings, with strings in all 10 locales.
- **Reporting**: the toggle state travels to redirect with the domain update, the way the DKIM key already does, so the account page can say whether the relay is actually on rather than only what the plan allows.

## Verification

`go build ./...` clean; `go test ./rest/... ./config/... ./event/... ./access/... ./redirect/...` pass, including tests for the credentials endpoint when enabled, toggled off, and without a token. `eslint` clean and `vite build` succeeds for the web app.

Exercised end to end against UAT: with the toggle on, a device authenticated to the relay on 465 and a message was delivered through SES.

## Follow-up

Surfacing plan and usage in the Email page, so an admin sees the monthly allowance next to the switch rather than only on the account site.