### PR TITLE
Skip the visual diff against stable 3084

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -10,7 +10,7 @@ local bootstrap = '25.02';
 local nginx = '1.24.0';
 local python = '3.12-slim-bookworm';
 local alpine = '3.21';
-local visual_diff_skip_build = '3076';
+local visual_diff_skip_build = '3084';
 
 local build(arch, testUI) = [{
   kind: 'pipeline',


### PR DESCRIPTION
One-line stopgap to unblock platform branch builds.

## Why

`FindLatestBuild("stable")` resolves to build 3084 (2026-08-19). The nightly artifact prune on the CI host deleted `platform/3084-*`, so `ci-diff` downloads an empty tree and every branch build fails:

```
Stable build: #3084
=== desktop ===
  SKIP: base=missing compare=artifact/playwright/desktop/screenshot
=== mobile ===
  SKIP: base=missing compare=artifact/playwright/mobile/screenshot
FAIL: no screenshots were compared stable
```

Nothing is wrong with the screenshots — the baseline no longer exists. This currently fails *every* platform PR, not just one.

`3076` was the previous occurrence of the same thing. The constant only takes effect when it equals the current latest stable, so it went inert the moment stable moved to 3084.

## What this does not fix

- `visual-diff/cmd/app.go:54` — `DownloadBuild` returns `nil` for a build directory that does not exist, so a pruned baseline is indistinguishable from a screenshot regression until you read the log.
- The constant still needs hand-bumping at each recurrence.

Both are worth a follow-up; this is the stopgap.

The baseline regenerates on the next stable push. Going forward it is protected from pruning by the artifact cleaner now running on the CI host, which keeps the last green stable per app regardless of age.

Validated with `drone jsonnet` + `drone lint`; generated step reads `ci-diff artifact/playwright 3084`.