### PR TITLE
Stop the OOM watcher killing apps on a healthy machine

### DIFF
--- a/backend/stability/meminfo.go
+++ b/backend/stability/meminfo.go
@@ -76,7 +76,7 @@ func (m *MemInfo) PSIAvailable() bool {
 	return err == nil
 }
 
-func (m *MemInfo) PSIMemoryAvg10() (float64, error) {
+func (m *MemInfo) PSIMemoryFullAvg10() (float64, error) {
 	f, err := os.Open(filepath.Join(m.procDir, "pressure", "memory"))
 	if err != nil {
 		return 0, err
@@ -85,7 +85,7 @@ func (m *MemInfo) PSIMemoryAvg10() (float64, error) {
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		line := sc.Text()
-		if !strings.HasPrefix(line, "some ") {
+		if !strings.HasPrefix(line, "full ") {
 			continue
 		}
 		for _, field := range strings.Fields(line) {
@@ -94,5 +94,5 @@ func (m *MemInfo) PSIMemoryAvg10() (float64, error) {
 			}
 		}
 	}
-	return 0, fmt.Errorf("pressure/memory: 'some avg10' missing")
+	return 0, fmt.Errorf("pressure/memory: 'full avg10' missing")
 }

--- a/backend/stability/meminfo_test.go
+++ b/backend/stability/meminfo_test.go
@@ -46,12 +46,19 @@ func TestPSIAvailability(t *testing.T) {
 	assert.True(t, m.PSIAvailable())
 }
 
-func TestPSIMemoryAvg10(t *testing.T) {
+func TestPSIMemoryFullAvg10(t *testing.T) {
 	dir := t.TempDir()
 	writeProcFile(t, dir, "pressure/memory", `some avg10=12.34 avg60=3.21 avg300=1.00 total=12345
 full avg10=4.50 avg60=1.00 avg300=0.50 total=678
 `)
-	v, err := NewMemInfo(dir).PSIMemoryAvg10()
+	v, err := NewMemInfo(dir).PSIMemoryFullAvg10()
 	require.NoError(t, err)
-	assert.InDelta(t, 12.34, v, 0.001)
+	assert.InDelta(t, 4.50, v, 0.001)
+}
+
+func TestPSIMemoryFullAvg10MissingFullLine(t *testing.T) {
+	dir := t.TempDir()
+	writeProcFile(t, dir, "pressure/memory", "some avg10=99.00 avg60=99.00 avg300=99.00 total=12345\n")
+	_, err := NewMemInfo(dir).PSIMemoryFullAvg10()
+	assert.Error(t, err)
 }

--- a/backend/stability/oom.go
+++ b/backend/stability/oom.go
@@ -12,17 +12,20 @@ import (
 type KillFn func(pid int, sig syscall.Signal) error
 
 type Watcher struct {
-	mem      *MemInfo
-	scan     *ProcScanner
-	protect  Protect
-	kill     KillFn
-	events   *EventLog
-	log      *zap.Logger
-	interval time.Duration
-	availMin float64
-	psiMax   float64
-	grace    time.Duration
-	selfPID  int
+	mem        *MemInfo
+	scan       *ProcScanner
+	protect    Protect
+	kill       KillFn
+	events     *EventLog
+	log        *zap.Logger
+	interval   time.Duration
+	availMin   float64
+	availPSI   float64
+	psiMax     float64
+	grace      time.Duration
+	cooldown   time.Duration
+	lastAction time.Time
+	selfPID    int
 }
 
 func NewWatcher(mem *MemInfo, scan *ProcScanner, kill KillFn, events *EventLog, log *zap.Logger) *Watcher {
@@ -35,8 +38,10 @@ func NewWatcher(mem *MemInfo, scan *ProcScanner, kill KillFn, events *EventLog, 
 		log:      log,
 		interval: 2 * time.Second,
 		availMin: 0.08,
-		psiMax:   40.0,
+		availPSI: 0.20,
+		psiMax:   20.0,
 		grace:    4 * time.Second,
+		cooldown: 60 * time.Second,
 		selfPID:  os.Getpid(),
 	}
 }
@@ -47,7 +52,9 @@ func (w *Watcher) Run() {
 	w.log.Info("oom-watcher: started",
 		zap.Duration("interval", w.interval),
 		zap.Float64("avail_min", w.availMin),
+		zap.Float64("avail_psi", w.availPSI),
 		zap.Float64("psi_max", w.psiMax),
+		zap.Duration("cooldown", w.cooldown),
 	)
 	for range t.C {
 		if err := w.tick(); err != nil {
@@ -65,7 +72,7 @@ func (w *Watcher) tick() error {
 	psi := 0.0
 	psiOK := false
 	if w.mem.PSIAvailable() {
-		if v, err := w.mem.PSIMemoryAvg10(); err == nil {
+		if v, err := w.mem.PSIMemoryFullAvg10(); err == nil {
 			psi = v
 			psiOK = true
 		}
@@ -73,6 +80,10 @@ func (w *Watcher) tick() error {
 	if !w.pressureExceeded(avail, psi, psiOK) {
 		return nil
 	}
+	if time.Since(w.lastAction) < w.cooldown {
+		return nil
+	}
+	w.lastAction = time.Now()
 	w.log.Warn("oom-watcher: pressure detected",
 		zap.Float64("avail_ratio", avail),
 		zap.Float64("psi_avg10", psi),
@@ -88,10 +99,7 @@ func (w *Watcher) pressureExceeded(avail, psi float64, psiOK bool) bool {
 	if avail < w.availMin {
 		return true
 	}
-	if psiOK && psi > w.psiMax {
-		return true
-	}
-	return false
+	return psiOK && psi > w.psiMax && avail < w.availPSI
 }
 
 func (w *Watcher) killWorst() error {

--- a/backend/stability/oom_test.go
+++ b/backend/stability/oom_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,13 +12,19 @@ import (
 )
 
 type fakeKill struct {
-	calls   []struct{ pid int; sig syscall.Signal }
+	calls []struct {
+		pid int
+		sig syscall.Signal
+	}
 	alive   map[int]bool
 	hookErr error
 }
 
 func (k *fakeKill) fn(pid int, sig syscall.Signal) error {
-	k.calls = append(k.calls, struct{ pid int; sig syscall.Signal }{pid, sig})
+	k.calls = append(k.calls, struct {
+		pid int
+		sig syscall.Signal
+	}{pid, sig})
 	if sig == 0 {
 		if k.alive[pid] {
 			return nil
@@ -30,11 +37,28 @@ func (k *fakeKill) fn(pid int, sig syscall.Signal) error {
 	return nil
 }
 
+func (k *fakeKill) signalled(sig syscall.Signal) int {
+	n := 0
+	for _, c := range k.calls {
+		if c.sig == sig {
+			n++
+		}
+	}
+	return n
+}
+
 func newWatcherWithProc(t *testing.T, memTotal, memAvail uint64, procDir string) *Watcher {
 	t.Helper()
-	root := t.TempDir()
-	procRoot := root
+	return newWatcherWithPSI(t, memTotal, memAvail, procDir, "")
+}
+
+func newWatcherWithPSI(t *testing.T, memTotal, memAvail uint64, procDir, psi string) *Watcher {
+	t.Helper()
+	procRoot := t.TempDir()
 	writeProcFile(t, procRoot, "meminfo", "MemTotal: "+strconvUint(memTotal)+" kB\nMemAvailable: "+strconvUint(memAvail)+" kB\n")
+	if psi != "" {
+		writeProcFile(t, procRoot, "pressure/memory", psi)
+	}
 	return NewWatcher(NewMemInfo(procRoot), NewProcScanner(procDir), nil, nil, zap.NewNop())
 }
 
@@ -84,10 +108,85 @@ func TestKillWorstReturnsErrNoVictim(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrNoVictim))
 }
 
-func TestPressureExceededByAvailOrPSI(t *testing.T) {
+func TestPressureExceededOnLowAvailRegardlessOfPSI(t *testing.T) {
 	w := NewWatcher(NewMemInfo(t.TempDir()), nil, nil, nil, zap.NewNop())
 	assert.True(t, w.pressureExceeded(0.05, 0, false))
+	assert.True(t, w.pressureExceeded(0.05, 0, true))
 	assert.False(t, w.pressureExceeded(0.30, 0, false))
-	assert.True(t, w.pressureExceeded(0.30, 50, true))
-	assert.False(t, w.pressureExceeded(0.30, 5, true))
+}
+
+func TestPressureNotExceededByPSIAloneWhenMemoryAvailable(t *testing.T) {
+	w := NewWatcher(NewMemInfo(t.TempDir()), nil, nil, nil, zap.NewNop())
+	assert.False(t, w.pressureExceeded(0.423, 43.3, true))
+	assert.False(t, w.pressureExceeded(0.605, 44.3, true))
+	assert.False(t, w.pressureExceeded(0.731, 42.6, true))
+}
+
+func TestPressureExceededWhenPSIHighAndMemoryLow(t *testing.T) {
+	w := NewWatcher(NewMemInfo(t.TempDir()), nil, nil, nil, zap.NewNop())
+	assert.True(t, w.pressureExceeded(0.15, 30, true))
+	assert.False(t, w.pressureExceeded(0.15, 5, true))
+	assert.False(t, w.pressureExceeded(0.15, 30, false))
+}
+
+func TestTickIgnoresHighSomePSIWhenMemoryAvailable(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "photoprism", rssKB: 1779000, cgroup: "0::/system.slice/snap.photoprism.web.service"})
+	w := newWatcherWithPSI(t, 12887000, 5448000, procDir,
+		"some avg10=43.30 avg60=20.00 avg300=5.00 total=1\nfull avg10=0.12 avg60=0.05 avg300=0.01 total=2\n")
+	k := &fakeKill{alive: map[int]bool{100: true}}
+	w.kill = k.fn
+	require.NoError(t, w.tick())
+	assert.Empty(t, k.calls)
+}
+
+func TestTickKillsWhenFullPSIHighAndMemoryLow(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "photoprism", rssKB: 1779000, cgroup: "0::/system.slice/snap.photoprism.web.service"})
+	w := newWatcherWithPSI(t, 12887000, 1288000, procDir,
+		"some avg10=90.00 avg60=80.00 avg300=70.00 total=1\nfull avg10=55.00 avg60=40.00 avg300=30.00 total=2\n")
+	k := &fakeKill{alive: map[int]bool{}}
+	w.kill = k.fn
+	require.NoError(t, w.tick())
+	require.NotEmpty(t, k.calls)
+	assert.Equal(t, syscall.SIGTERM, k.calls[0].sig)
+}
+
+func TestTickWithoutPSIStillKillsOnLowAvail(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "photoprism", rssKB: 500000, cgroup: "0::/x"})
+	w := newWatcherWithProc(t, 4000000, 100000, procDir)
+	assert.False(t, w.mem.PSIAvailable())
+	k := &fakeKill{alive: map[int]bool{}}
+	w.kill = k.fn
+	require.NoError(t, w.tick())
+	require.NotEmpty(t, k.calls)
+	assert.Equal(t, syscall.SIGTERM, k.calls[0].sig)
+}
+
+func TestTickCooldownPreventsKillCascade(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "photoprism", rssKB: 1779000, cgroup: "0::/a"})
+	writeFakeProc(t, procDir, fakeProc{pid: 101, name: "jellyfin", rssKB: 1635000, cgroup: "0::/b"})
+	writeFakeProc(t, procDir, fakeProc{pid: 102, name: "syncthing", rssKB: 1398000, cgroup: "0::/c"})
+	w := newWatcherWithProc(t, 4000000, 100000, procDir)
+	k := &fakeKill{alive: map[int]bool{}}
+	w.kill = k.fn
+	require.NoError(t, w.tick())
+	require.NoError(t, w.tick())
+	require.NoError(t, w.tick())
+	assert.Equal(t, 1, k.signalled(syscall.SIGTERM))
+	assert.Equal(t, 100, k.calls[0].pid)
+}
+
+func TestTickKillsAgainAfterCooldownExpires(t *testing.T) {
+	procDir := t.TempDir()
+	writeFakeProc(t, procDir, fakeProc{pid: 100, name: "photoprism", rssKB: 1779000, cgroup: "0::/a"})
+	w := newWatcherWithProc(t, 4000000, 100000, procDir)
+	k := &fakeKill{alive: map[int]bool{}}
+	w.kill = k.fn
+	require.NoError(t, w.tick())
+	w.lastAction = time.Now().Add(-2 * w.cooldown)
+	require.NoError(t, w.tick())
+	assert.Equal(t, 2, k.signalled(syscall.SIGTERM))
 }

--- a/web/platform/src/locales/ar.json
+++ b/web/platform/src/locales/ar.json
@@ -364,8 +364,9 @@
     "swapIn": "داخل",
     "swapOut": "خارج",
     "kindZramEnabled": "تم تمكين zram",
+    "kindZramModuleLoaded": "تم تحميل وحدة zram",
     "kindSwapoffFile": "تم تعطيل ملف التبديل",
-    "kindPressure": "تم اكتشاف ضغط على الذاكرة",
+    "kindPressureDetected": "تم اكتشاف ضغط على الذاكرة",
     "kindVictimSigterm": "تم إنهاء العملية (SIGTERM)",
     "kindVictimSigkill": "تم قتل العملية (SIGKILL)"
   },

--- a/web/platform/src/locales/de.json
+++ b/web/platform/src/locales/de.json
@@ -364,8 +364,9 @@
     "swapIn": "rein",
     "swapOut": "raus",
     "kindZramEnabled": "zram aktiviert",
+    "kindZramModuleLoaded": "zram-Modul geladen",
     "kindSwapoffFile": "Auslagerungsdatei deaktiviert",
-    "kindPressure": "Speicherengpass erkannt",
+    "kindPressureDetected": "Speicherengpass erkannt",
     "kindVictimSigterm": "Prozess beendet (SIGTERM)",
     "kindVictimSigkill": "Prozess gekillt (SIGKILL)"
   },

--- a/web/platform/src/locales/en.json
+++ b/web/platform/src/locales/en.json
@@ -82,8 +82,9 @@
     "swapIn": "in",
     "swapOut": "out",
     "kindZramEnabled": "zram enabled",
+    "kindZramModuleLoaded": "zram module loaded",
     "kindSwapoffFile": "file swap disabled",
-    "kindPressure": "memory pressure detected",
+    "kindPressureDetected": "memory pressure detected",
     "kindVictimSigterm": "process terminated (SIGTERM)",
     "kindVictimSigkill": "process killed (SIGKILL)"
   },

--- a/web/platform/src/locales/es.json
+++ b/web/platform/src/locales/es.json
@@ -364,8 +364,9 @@
     "swapIn": "entra",
     "swapOut": "sale",
     "kindZramEnabled": "zram activado",
+    "kindZramModuleLoaded": "módulo zram cargado",
     "kindSwapoffFile": "archivo de intercambio desactivado",
-    "kindPressure": "presión de memoria detectada",
+    "kindPressureDetected": "presión de memoria detectada",
     "kindVictimSigterm": "proceso terminado (SIGTERM)",
     "kindVictimSigkill": "proceso matado (SIGKILL)"
   },

--- a/web/platform/src/locales/fr.json
+++ b/web/platform/src/locales/fr.json
@@ -364,8 +364,9 @@
     "swapIn": "entrée",
     "swapOut": "sortie",
     "kindZramEnabled": "zram activé",
+    "kindZramModuleLoaded": "module zram chargé",
     "kindSwapoffFile": "fichier swap désactivé",
-    "kindPressure": "pression mémoire détectée",
+    "kindPressureDetected": "pression mémoire détectée",
     "kindVictimSigterm": "processus terminé (SIGTERM)",
     "kindVictimSigkill": "processus tué (SIGKILL)"
   },

--- a/web/platform/src/locales/hi.json
+++ b/web/platform/src/locales/hi.json
@@ -364,8 +364,9 @@
     "swapIn": "अंदर",
     "swapOut": "बाहर",
     "kindZramEnabled": "zram सक्षम",
+    "kindZramModuleLoaded": "zram मॉड्यूल लोड किया गया",
     "kindSwapoffFile": "फ़ाइल स्वैप अक्षम",
-    "kindPressure": "मेमोरी दबाव का पता चला",
+    "kindPressureDetected": "मेमोरी दबाव का पता चला",
     "kindVictimSigterm": "प्रक्रिया समाप्त (SIGTERM)",
     "kindVictimSigkill": "प्रक्रिया मार दी गई (SIGKILL)"
   },

--- a/web/platform/src/locales/ja.json
+++ b/web/platform/src/locales/ja.json
@@ -364,8 +364,9 @@
     "swapIn": "入",
     "swapOut": "出",
     "kindZramEnabled": "zram を有効化",
+    "kindZramModuleLoaded": "zram モジュールを読み込み",
     "kindSwapoffFile": "ファイルスワップを無効化",
-    "kindPressure": "メモリ圧迫を検出",
+    "kindPressureDetected": "メモリ圧迫を検出",
     "kindVictimSigterm": "プロセス終了 (SIGTERM)",
     "kindVictimSigkill": "プロセス強制終了 (SIGKILL)"
   },

--- a/web/platform/src/locales/pt.json
+++ b/web/platform/src/locales/pt.json
@@ -364,8 +364,9 @@
     "swapIn": "entra",
     "swapOut": "sai",
     "kindZramEnabled": "zram ativado",
+    "kindZramModuleLoaded": "módulo zram carregado",
     "kindSwapoffFile": "arquivo de swap desativado",
-    "kindPressure": "pressão de memória detectada",
+    "kindPressureDetected": "pressão de memória detectada",
     "kindVictimSigterm": "processo encerrado (SIGTERM)",
     "kindVictimSigkill": "processo morto (SIGKILL)"
   },

--- a/web/platform/src/locales/ru.json
+++ b/web/platform/src/locales/ru.json
@@ -364,8 +364,9 @@
     "swapIn": "вход",
     "swapOut": "выход",
     "kindZramEnabled": "zram включён",
+    "kindZramModuleLoaded": "модуль zram загружен",
     "kindSwapoffFile": "файл подкачки отключён",
-    "kindPressure": "обнаружена нехватка памяти",
+    "kindPressureDetected": "обнаружена нехватка памяти",
     "kindVictimSigterm": "процесс завершён (SIGTERM)",
     "kindVictimSigkill": "процесс убит (SIGKILL)"
   },

--- a/web/platform/src/locales/zh-CN.json
+++ b/web/platform/src/locales/zh-CN.json
@@ -364,8 +364,9 @@
     "swapIn": "换入",
     "swapOut": "换出",
     "kindZramEnabled": "已启用 zram",
+    "kindZramModuleLoaded": "已加载 zram 模块",
     "kindSwapoffFile": "已禁用文件交换",
-    "kindPressure": "检测到内存压力",
+    "kindPressureDetected": "检测到内存压力",
     "kindVictimSigterm": "进程已终止 (SIGTERM)",
     "kindVictimSigkill": "进程被强制结束 (SIGKILL)"
   },


### PR DESCRIPTION
Reported on the forum: [Device health logged events](https://syncloud.discourse.group/t/device-health-logged-events/675). Ryan's box has 12 GB RAM with 10 GB `MemAvailable`, load 0.15, uptime 5 days — and the watcher still SIGTERMed three apps back to back:

| avail | psi | victim |
|---|---|---|
| 42.3% | 43.3 | `photoprism.web` (1779 MB) |
| 60.5% | 44.3 | `jellyfin.server` (1635 MB) |
| 73.1% | 42.6 | `syncthing` (1398 MB) |

Availability went **up** after every kill. The machine was never short of memory.

## Three defects in the PSI branch from #731

1. `pressureExceeded` ORed `avail < 8%` with `psi > 40`, so PSI alone could order a kill with no check that memory was actually low.

2. The PSI figure came from the `some` line of `/proc/pressure/memory`. `some` counts *any* task stalled on memory for any reason — page-cache refaults during a large sequential read push it over 40 on a perfectly healthy box. PhotoPrism's scheduled index is exactly that workload, which is why the same app kept getting named: whichever app does the heavy I/O both drives `some` up and has the highest RSS, so `ProcScanner.Candidates` picks it. Now reads `full`, which only rises when every task is stalled.

3. No cooldown. `interval` is 2s, `grace` 4s, and avg10 decays over ~10s, so one burst of cache pressure emptied the top of the RSS list before the metric could settle. Hence three kills in a row.

## After

| | no PSI | PSI present |
|---|---|---|
| before | `avail < 0.08` | `avail < 0.08` OR `some > 40` |
| after | `avail < 0.08` | `avail < 0.08` OR (`full > 20` AND `avail < 0.20`) |

Plus a 60s cooldown after any action, checked before the pressure event is logged so a single burst can neither cascade nor spam the event log.

## Kernels without PSI are unaffected

`PSIAvailable()` gates the whole branch, so on a kernel without `/proc/pressure/memory` the rule reduces to `avail < 0.08` — exactly what it was before the PSI branch existed. That covers the legacy Odroid HC4 image this daemon was originally written for (#731 was a response to [topic 650](https://syncloud.discourse.group/t/650)). Locked in by `TestTickWithoutPSIStillKillsOnLowAvail`, which asserts `PSIAvailable()` is false and still expects the SIGTERM.

**Not a pure narrowing.** The new PSI term can fire where the old one didn't — e.g. `full=25`, `some=35`, `avail=15%`. That case is a machine genuinely thrashing with memory under 20%, which is the original "unresponsive even to SSH" scenario, so catching it earlier is intended. But on a 4 GB HC4 mid-index it could mean more kills than before, not fewer. Raising `availPSI` to 0.12 or `psiMax` back to 40 would make it a near-subset of the old behaviour if we'd rather ship conservative first.

## Health page i18n

Ryan's screenshot showed the raw key `health.kindPressureDetected`. The backend kind is `pressure_detected`, which `Health.vue` camel-cases to `kindPressureDetected`, but the locales defined it as `kindPressure`. Renamed across all ten locales and added the missing `kindZramModuleLoaded`.

## Prior reports of the same symptom

- [650](https://syncloud.discourse.group/t/650) — the original freeze that motivated #731
- [653](https://syncloud.discourse.group/t/653) — workaround guide telling users to expect indexing to be killed
- [654](https://syncloud.discourse.group/t/654) — repeated kills, closed unresolved
- [660](https://syncloud.discourse.group/t/660) — a two-month manual restart workflow built around the kills

## Testing

`go test ./stability/...` and the web suite (lint + 129 unit tests) pass locally. CI build 3089.