### PR TITLE
Format the backend and fail the build on unformatted go

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -127,6 +127,8 @@ local build(arch, testUI) = [{
              commands: [
                'cd backend',
                'for i in 1 2 3; do go mod download && break || sleep 5; done',
+               'gofmt -l . | tee /tmp/gofmt.backend',
+               'test ! -s /tmp/gofmt.backend',
                'go test ./... -coverprofile cover.out',
                'go tool cover -func cover.out',
                "CGO_ENABLED=0 go build -o ../build/snap/bin/backend ./cmd/backend",
@@ -144,6 +146,8 @@ local build(arch, testUI) = [{
                "CGO_ENABLED=0 go build -o ../build/snap/bin/login ./cmd/login",
                "CGO_ENABLED=0 go build -o ../build/snap/bin/stability ./cmd/stability",
                'cd ../visual-diff',
+               'gofmt -l . | tee /tmp/gofmt.visual-diff',
+               'test ! -s /tmp/gofmt.visual-diff',
                'CGO_ENABLED=0 go build -o visual-diff ./cmd',
              ],
            },

--- a/backend/auth/authelia.go
+++ b/backend/auth/authelia.go
@@ -7,12 +7,12 @@ import (
 	"encoding/pem"
 	"fmt"
 	"github.com/google/uuid"
-	_ "modernc.org/sqlite"
 	"github.com/syncloud/platform/cli"
 	"github.com/syncloud/platform/config"
 	"github.com/syncloud/platform/parser"
 	"go.uber.org/zap"
 	"io"
+	_ "modernc.org/sqlite"
 	"os"
 	"path"
 	"path/filepath"
@@ -29,16 +29,16 @@ func autheliaDSN(sqlitePath string) string {
 }
 
 type Variables struct {
-	Domain            string
-	AppUrl            string
-	EncryptionKey     string
-	JwtSecret         string
-	HmacSecret        string
-	DeviceUrl         string
-	AuthUrl           string
-	IsActivated       bool
-	TwoFactorEnabled  bool
-	OIDCClients       []config.OIDCClient
+	Domain           string
+	AppUrl           string
+	EncryptionKey    string
+	JwtSecret        string
+	HmacSecret       string
+	DeviceUrl        string
+	AuthUrl          string
+	IsActivated      bool
+	TwoFactorEnabled bool
+	OIDCClients      []config.OIDCClient
 }
 
 type HealthWaiter interface {

--- a/backend/auth/oidc.go
+++ b/backend/auth/oidc.go
@@ -51,11 +51,11 @@ func (s *OIDCService) GetAuthorizationURL() (authURL string, state string, codeV
 
 	params := url.Values{
 		"client_id":             {"syncloud"},
-		"response_type":        {"code"},
-		"redirect_uri":         {redirectURI},
-		"scope":                {"openid profile email groups"},
-		"state":                {state},
-		"code_challenge":       {codeChallenge},
+		"response_type":         {"code"},
+		"redirect_uri":          {redirectURI},
+		"scope":                 {"openid profile email groups"},
+		"state":                 {state},
+		"code_challenge":        {codeChallenge},
 		"code_challenge_method": {"S256"},
 	}
 
@@ -173,7 +173,7 @@ func extractUsernameFromIDToken(idToken string) (string, error) {
 
 	var claims struct {
 		PreferredUsername string `json:"preferred_username"`
-		Subject          string `json:"sub"`
+		Subject           string `json:"sub"`
 	}
 	if err := json.Unmarshal(payload, &claims); err != nil {
 		return "", fmt.Errorf("parse id_token claims: %w", err)

--- a/backend/config/db.go
+++ b/backend/config/db.go
@@ -3,9 +3,9 @@ package config
 import (
 	"database/sql"
 	"fmt"
-	_ "modernc.org/sqlite"
 	"go.uber.org/zap"
 	"log"
+	_ "modernc.org/sqlite"
 	"strconv"
 )
 

--- a/backend/config/user_config_test.go
+++ b/backend/config/user_config_test.go
@@ -82,4 +82,3 @@ func TestDeviceUrl_NonStandardPort(t *testing.T) {
 	url := config.Url("app1")
 	assert.Equal(t, "https://app1.domain.tld:10000", url)
 }
-

--- a/backend/session/cookies.go
+++ b/backend/session/cookies.go
@@ -74,7 +74,6 @@ func (c *Cookies) GetSessionUser(r *http.Request) (string, error) {
 	return user.(string), nil
 }
 
-
 func (c *Cookies) SetOIDCState(w http.ResponseWriter, r *http.Request, state string, codeVerifier string) error {
 	session := c.getSession(r)
 	session.Values[OIDCStateKey] = state

--- a/backend/stability/events.go
+++ b/backend/stability/events.go
@@ -111,7 +111,7 @@ func (l *EventLog) readLastLocked(limit int, reverse bool) ([]Event, error) {
 	for i := 0; i < count; i++ {
 		var idx int
 		if reverse {
-			idx = ((n - 1 - i) % limit + limit) % limit
+			idx = ((n-1-i)%limit + limit) % limit
 		} else {
 			start := 0
 			if n > limit {


### PR DESCRIPTION
Six backend files had drifted from `gofmt`: import ordering in `config/db.go`, stray blank lines in `session/cookies.go` and `config/user_config_test.go`, operator spacing in `stability/events.go`, and alignment in the two `auth` files. Every hunk is whitespace or import order — no behaviour changes.

Nothing caught this because the pipeline never ran `gofmt`, so the drift accumulated freely and any unrelated change risked picking up a formatting hunk in its diff.

The `build` step now lists offenders and then fails on any, for both the `backend` and `visual-diff` modules:

```
gofmt -l . | tee /tmp/gofmt.backend
test ! -s /tmp/gofmt.backend
```

Listing before failing means the log names the offending files rather than just going red. Verified both directions locally — clean tree passes, a deliberately misformatted file is listed and fails the step. `drone jsonnet` + `drone lint` clean, and the gate is present in all three arch pipelines.