### PR TITLE
Write the version file the publisher reads

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -61,6 +61,7 @@ echo "- ${ARCH}" >> ${BUILD_DIR}/meta/snap.yaml
 
 PACKAGE=${NAME}_${VERSION}_${ARCH}.snap
 echo ${PACKAGE} > $DIR/package.name
+echo ${VERSION} > $DIR/version
 mksquashfs ${BUILD_DIR} ${DIR}/${PACKAGE} -noappend -comp xz -no-xattrs -all-root
 mkdir ${DIR}/artifact
 cp ${DIR}/${PACKAGE} ${DIR}/artifact

--- a/web/e2e/specs/04-settings.spec.ts
+++ b/web/e2e/specs/04-settings.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from '@playwright/test'
 import { login } from '../helpers/login'
-import { menu, settings, clickElSelect, waitForLoading } from '../helpers/ui'
+import { menu, settings, clickElSelect } from '../helpers/ui'
 import { ssh } from '../helpers/ssh'
 import { shoot } from '../helpers/screenshot'
 
@@ -98,8 +98,9 @@ test('settings locale', async ({}, testInfo) => {
   await page.keyboard.type('Asia/Tokyo')
   await page.waitForTimeout(1000)
   await page.locator('#settings_tz_Asia_Tokyo').click()
+  const saved = page.waitForResponse(r => r.url().includes('/rest/timezone') && r.request().method() === 'POST')
   await page.locator('#btn_save_timezone').click()
-  await waitForLoading(page)
+  await saved
   const tz = ssh('cat /etc/timezone').trim()
   expect(tz).toBe('Asia/Tokyo')
   await page.waitForTimeout(2000)


### PR DESCRIPTION
The master build after #771 failed in `publish`:

```
Error: read version: open version: no such file or directory
```

`store-publisher` derives the snap it uploads from `snap.yaml` and `./version`:

```
-f, --file  snap file path (default: <app-dir>/<name>_<version>_<arch>.snap
            derived from snap.yaml and ./version)
```

#771 dropped the `version` step that created that file. I checked the repo for readers and found only the package step, which no longer needed it — but the publisher is a binary in another image, so its dependency was not visible to a grep of this tree.

`package.sh` writes it now, beside the `package.name` it already writes. It is handed the version and builds the snap whose name encodes it, so it is the right place to record what was used. Contents are unchanged from what the old step produced: the build number and a newline, verified byte-identical.

## Verification gap worth naming

**A branch build cannot prove this fix.** The `publish` step is gated `when: {branch: [master, stable]}`, so it does not run here — which is exactly why the original regression survived 22 green branch builds. The real check is the master build after this merges.